### PR TITLE
[RAC] [RBAC] adds function to get alerts-as-data index name

### DIFF
--- a/x-pack/plugins/alerting/server/authorization/alerting_authorization.mock.ts
+++ b/x-pack/plugins/alerting/server/authorization/alerting_authorization.mock.ts
@@ -16,6 +16,7 @@ const createAlertingAuthorizationMock = () => {
     ensureAuthorized: jest.fn(),
     filterByRuleTypeAuthorization: jest.fn(),
     getFindAuthorizationFilter: jest.fn(),
+    getAuthorizedAlertsIndices: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
@@ -13,6 +13,7 @@ import {
   getApmIndexSettings,
 } from '../../lib/settings/apm_indices/get_apm_indices';
 import { saveApmIndices } from '../../lib/settings/apm_indices/save_apm_indices';
+// import { APM_SERVER_FEATURE_ID } from '../../../common/alert_types';
 
 // get list of apm indices and values
 const apmIndexSettingsRoute = createApmServerRoute({
@@ -63,7 +64,29 @@ const saveApmIndicesRoute = createApmServerRoute({
   },
 });
 
+// const getApmAlertsAsDataIndexRoute = createApmServerRoute({
+//   endpoint: 'GET /api/apm/settings/apm-alerts-as-data-indices',
+//   options: { tags: ['access:apm'] },
+//   handler: async (resources) => {
+//     const { context } = resources;
+//     console.error(context);
+//     const alertsAsDataClient = await context.rac?.getAlertsClient();
+//     if (alertsAsDataClient == null) {
+//       throw new Error('Missing alerts as data client');
+//     }
+//     const res = await alertsAsDataClient.getAlertsIndex([
+//       APM_SERVER_FEATURE_ID,
+//       'siem',
+//     ]);
+//     console.error('RESPONSE', JSON.stringify(res, null, 2));
+//     return res[0];
+//     // return alertsAsDataClient.getFullAssetName();
+//     // return ruleDataClient.getIndexName();
+//   },
+// });
+
 export const apmIndicesRouteRepository = createApmServerRouteRepository()
   .add(apmIndexSettingsRoute)
   .add(apmIndicesRoute)
   .add(saveApmIndicesRoute);
+// .add(getApmAlertsAsDataIndexRoute);

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -14,6 +14,7 @@ import {
 } from 'src/core/server';
 import { RuleDataClient } from '../../../rule_registry/server';
 import { AlertingApiRequestHandlerContext } from '../../../alerting/server';
+import type { RacApiRequestHandlerContext } from '../../../rule_registry/server';
 import { LicensingApiRequestHandlerContext } from '../../../licensing/server';
 import { APMConfig } from '..';
 import { APMPluginDependencies } from '../types';
@@ -21,6 +22,7 @@ import { APMPluginDependencies } from '../types';
 export interface ApmPluginRequestHandlerContext extends RequestHandlerContext {
   licensing: LicensingApiRequestHandlerContext;
   alerting: AlertingApiRequestHandlerContext;
+  rac: RacApiRequestHandlerContext;
 }
 
 export type InspectResponse = Array<{

--- a/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.mock.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.mock.ts
@@ -16,6 +16,7 @@ const createAlertsClientMock = () => {
     get: jest.fn(),
     getAlertsIndex: jest.fn(),
     update: jest.fn(),
+    getFullAssetName: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
@@ -68,23 +68,10 @@ export class AlertsClient {
     return this.ruleDataService?.getFullAssetName();
   }
 
-  /**
-   * OUTDATED: we are "hard coding" this string similar to how rule registry is doing it
-   * x-pack/plugins/apm/server/plugin.ts:191
-   */
   public async getAlertsIndex(featureIds: string[]) {
     return this.authorization.getAuthorizedAlertsIndices(
       featureIds.length !== 0 ? featureIds : ['apm', 'siem']
     );
-    // const indexExists = await this.ruleDataService?.assertFullAssetNameExists(assetName);
-    // this.logger.debug(`DOES THE INDEX EXIST? ${JSON.stringify(indexExists)}`);
-    // const fullAssetName = this.ruleDataService?.getFullAssetName(assetName);
-    // if (indexExists) {
-    //   return fullAssetName;
-    // }
-    // const errorMessage = `Missing index alias ${fullAssetName} not found for given asset name ${assetName}`;
-    // this.logger.error(errorMessage);
-    // throw new Error(errorMessage);
   }
 
   private async fetchAlert({ id, indexName }: GetAlertParams): Promise<ParsedTechnicalFields> {

--- a/x-pack/plugins/rule_registry/server/alert_data_client/tests/get.test.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/tests/get.test.ts
@@ -57,7 +57,7 @@ describe('get()', () => {
         },
       })
     );
-    const result = await alertsClient.get({ id: '1', assetName: 'observability-apm' });
+    const result = await alertsClient.get({ id: '1', indexName: '.alerts-observability-apm' });
     expect(result).toMatchInlineSnapshot(`
       Object {
         "kibana.rac.alert.owner": "apm",
@@ -88,7 +88,7 @@ describe('get()', () => {
     esClientMock.get.mockRejectedValue(error);
 
     await expect(
-      alertsClient.get({ id: '1', assetName: 'observability-apm' })
+      alertsClient.get({ id: '1', indexName: '.alerts-observability-apm' })
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"something when wrong"`);
     expect(auditLogger.log).toHaveBeenCalledWith({
       error: { code: 'Error', message: 'something when wrong' },
@@ -119,7 +119,7 @@ describe('get()', () => {
 
     test('returns alert if user is authorized to read alert under the consumer', async () => {
       const alertsClient = new AlertsClient(alertsClientParams);
-      const result = await alertsClient.get({ id: '1', assetName: 'observability-apm' });
+      const result = await alertsClient.get({ id: '1', indexName: '.alerts-observability-apm' });
 
       expect(alertingAuthMock.ensureAuthorized).toHaveBeenCalledWith({
         entity: 'alert',
@@ -144,7 +144,7 @@ describe('get()', () => {
       );
 
       await expect(
-        alertsClient.get({ id: '1', assetName: 'observability-apm' })
+        alertsClient.get({ id: '1', indexName: '.alerts-observability-apm' })
       ).rejects.toMatchInlineSnapshot(
         `[Error: Unauthorized to get a "apm.error_rate" alert for "apm"]`
       );

--- a/x-pack/plugins/rule_registry/server/alert_data_client/tests/update.test.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/tests/update.test.ts
@@ -88,7 +88,7 @@ describe('update()', () => {
     const result = await alertsClient.update({
       id: '1',
       data: { status: 'closed' },
-      assetName: 'observability-apm',
+      indexName: '.alerts-observability-apm',
     });
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -133,7 +133,7 @@ describe('update()', () => {
       alertsClient.update({
         id: '1',
         data: { status: 'closed' },
-        assetName: 'observability-apm',
+        indexName: '.alerts-observability-apm',
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"something when wrong on get"`);
     expect(auditLogger.log).toHaveBeenCalledWith({
@@ -173,7 +173,7 @@ describe('update()', () => {
       alertsClient.update({
         id: '1',
         data: { status: 'closed' },
-        assetName: 'observability-apm',
+        indexName: '.alerts-observability-apm',
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"something when wrong on update"`);
     expect(auditLogger.log).toHaveBeenCalledWith({
@@ -242,7 +242,7 @@ describe('update()', () => {
       const result = await alertsClient.update({
         id: '1',
         data: { status: 'closed' },
-        assetName: 'observability-apm',
+        indexName: '.alerts-observability-apm',
       });
 
       expect(alertingAuthMock.ensureAuthorized).toHaveBeenCalledWith({
@@ -271,7 +271,7 @@ describe('update()', () => {
         alertsClient.update({
           id: '1',
           data: { status: 'closed' },
-          assetName: 'observability-apm',
+          indexName: '.alerts-observability-apm',
         })
       ).rejects.toMatchInlineSnapshot(
         `[Error: Unauthorized to get a "apm.error_rate" alert for "apm"]`

--- a/x-pack/plugins/rule_registry/server/plugin.ts
+++ b/x-pack/plugins/rule_registry/server/plugin.ts
@@ -117,7 +117,7 @@ export class RuleRegistryPlugin
     // handler is called when '/path' resource is requested with `GET` method
     router.get({ path: '/rac-myfakepath', validate: false }, async (context, req, res) => {
       const racClient = await context.rac.getAlertsClient();
-      racClient?.get({ id: 'hello world', assetName: 'observability-apm' });
+      racClient?.get({ id: 'hello world', indexName: '.alerts-observability-apm' });
       return res.ok();
     });
 

--- a/x-pack/plugins/rule_registry/server/routes/index.ts
+++ b/x-pack/plugins/rule_registry/server/routes/index.ts
@@ -9,8 +9,10 @@ import { IRouter } from 'kibana/server';
 import { RacRequestHandlerContext } from '../types';
 import { getAlertByIdRoute } from './get_alert_by_id';
 import { updateAlertByIdRoute } from './update_alert_by_id';
+import { getAlertsIndexRoute } from './get_alert_index';
 
 export function defineRoutes(router: IRouter<RacRequestHandlerContext>) {
   getAlertByIdRoute(router);
   updateAlertByIdRoute(router);
+  getAlertsIndexRoute(router);
 }

--- a/x-pack/plugins/rule_registry/server/routes/update_alert_by_id.ts
+++ b/x-pack/plugins/rule_registry/server/routes/update_alert_by_id.ts
@@ -21,7 +21,7 @@ export const updateAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) 
         body: schema.object({
           status: schema.string(),
           ids: schema.arrayOf(schema.string()),
-          assetName: schema.string(),
+          indexName: schema.string(),
         }),
       },
       options: {
@@ -31,12 +31,12 @@ export const updateAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) 
     async (context, req, response) => {
       try {
         const racClient = await context.rac.getAlertsClient();
-        const { status, ids, assetName } = req.body;
+        const { status, ids, indexName } = req.body;
 
         const thing = await racClient?.update({
           id: ids[0],
           data: { status },
-          assetName,
+          indexName,
         });
         return response.ok({ body: { success: true, alerts: thing } });
       } catch (exc) {

--- a/x-pack/plugins/rule_registry/server/rule_data_client/index.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_client/index.ts
@@ -26,6 +26,11 @@ export class RuleDataClient implements IRuleDataClient {
     return await this.options.getClusterClient();
   }
 
+  getIndexName() {
+    // const index = `${[this.options.alias, options.namespace].filter(Boolean).join('-')}*`;
+    return this.options.alias;
+  }
+
   getReader(options: { namespace?: string } = {}): RuleDataReader {
     const index = `${[this.options.alias, options.namespace].filter(Boolean).join('-')}*`;
 

--- a/x-pack/plugins/rule_registry/server/rule_data_plugin_service/index.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_plugin_service/index.ts
@@ -16,6 +16,7 @@ import {
 import { ecsComponentTemplate } from '../../common/assets/component_templates/ecs_component_template';
 import { defaultLifecyclePolicy } from '../../common/assets/lifecycle_policies/default_lifecycle_policy';
 import { ClusterPutComponentTemplateBody, PutIndexTemplateRequest } from '../../common/types';
+// import { ClusterClient } from 'src/core/server/elasticsearch/client';
 
 const BOOTSTRAP_TIMEOUT = 60000;
 
@@ -50,8 +51,11 @@ function createSignal() {
 
 export class RuleDataPluginService {
   signal = createSignal();
+  private readonly fullAssetName;
 
-  constructor(private readonly options: RuleDataPluginServiceConstructorOptions) {}
+  constructor(private readonly options: RuleDataPluginServiceConstructorOptions) {
+    this.fullAssetName = options.index;
+  }
 
   private assertWriteEnabled() {
     if (!this.isWriteEnabled) {
@@ -153,6 +157,14 @@ export class RuleDataPluginService {
   }
 
   getFullAssetName(assetName?: string) {
-    return [this.options.index, assetName].filter(Boolean).join('-');
+    // return [this.options.index, assetName].filter(Boolean).join('-');
+    return [this.fullAssetName, assetName].filter(Boolean).join('-');
+  }
+
+  async assertFullAssetNameExists(assetName?: string) {
+    const fullAssetName = this.getFullAssetName(assetName);
+    const clusterClient = await this.getClusterClient();
+    const { body } = await clusterClient.indices.exists({ index: fullAssetName });
+    return body;
   }
 }

--- a/x-pack/plugins/rule_registry/server/rule_data_plugin_service/rule_data_plugin_service.mock.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_plugin_service/rule_data_plugin_service.mock.ts
@@ -20,6 +20,7 @@ const createRuleDataPluginServiceMock = (_: RuleDataPluginServiceConstructorOpti
     createOrUpdateComponentTemplate: jest.fn(),
     createOrUpdateIndexTemplate: jest.fn(),
     createOrUpdateLifecyclePolicy: jest.fn(),
+    assertFullAssetNameExists: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/plugins/rule_registry/server/scripts/get_alerts_index.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/get_alerts_index.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+set -e
+
+USER=${1:-'observer'}
+ASSET_NAME=${2:-'observability-apm'}
+
+cd ./hunter && sh ./post_detections_role.sh && sh ./post_detections_user.sh
+cd ../observer && sh ./post_detections_role.sh && sh ./post_detections_user.sh
+cd ..
+
+# Example: ./find_rules.sh
+curl -v -k \
+ -u $USER:changeme \
+ -X GET "${KIBANA_URL}${SPACE_URL}/api/rac/alerts/index?assetName=siem" | jq .
+
+# -X GET "${KIBANA_URL}${SPACE_URL}/api/apm/settings/apm-alerts-as-data-indices" | jq .


### PR DESCRIPTION
## Summary

cd into `x-pack/plugins/rule_registry/server/scripts` and execute `./get_alerts_index.sh`

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
