### PR TITLE
squashed commit

### DIFF
--- a/x-pack/plugins/alerting/server/authorization/alerting_authorization.mock.ts
+++ b/x-pack/plugins/alerting/server/authorization/alerting_authorization.mock.ts
@@ -16,13 +16,13 @@ const createAlertingAuthorizationMock = () => {
     ensureAuthorized: jest.fn(),
     filterByRuleTypeAuthorization: jest.fn(),
     getFindAuthorizationFilter: jest.fn(),
-    getAuthorizedAlertsIndices: jest.fn(),
+    getAugmentRuleTypesWithAuthorization: jest.fn(),
   };
   return mocked;
 };
 
 export const alertingAuthorizationMock: {
-  create: () => jest.Mocked<PublicMethodsOf<AlertingAuthorization>>; // AlertingAuthorizationMock;
+  create: () => jest.Mocked<PublicMethodsOf<AlertingAuthorization>>;
 } = {
   create: createAlertingAuthorizationMock,
 };

--- a/x-pack/plugins/apm/server/feature.ts
+++ b/x-pack/plugins/apm/server/feature.ts
@@ -75,7 +75,7 @@ export const APM_FEATURE = {
   },
   subFeatures: [
     {
-      name: i18n.translate('xpack.apm.featureRegistry.manageAlerts', {
+      name: i18n.translate('xpack.apm.featureRegistry.manageAlertsName', {
         defaultMessage: 'Manage Alerts',
       }),
       privilegeGroups: [

--- a/x-pack/plugins/apm/server/feature.ts
+++ b/x-pack/plugins/apm/server/feature.ts
@@ -76,24 +76,44 @@ export const APM_FEATURE = {
   subFeatures: [
     {
       name: i18n.translate('xpack.apm.featureRegistry.manageAlertsName', {
-        defaultMessage: 'Manage Alerts',
+        defaultMessage: 'Alerts',
       }),
       privilegeGroups: [
         {
-          groupType: 'independent' as SubFeaturePrivilegeGroupType,
+          groupType: 'mutually_exclusive' as SubFeaturePrivilegeGroupType,
           privileges: [
             {
-              id: 'alert_manage',
+              id: 'alerts_all',
               name: i18n.translate(
-                'xpack.apm.featureRegistry.subfeature.apmFeatureName',
+                'xpack.apm.featureRegistry.subfeature.alertsAllName',
                 {
-                  defaultMessage: 'Manage Alerts',
+                  defaultMessage: 'All',
                 }
               ),
               includeIn: 'all' as 'all',
               alerting: {
                 alert: {
                   all: Object.values(AlertType),
+                },
+              },
+              savedObject: {
+                all: [],
+                read: [],
+              },
+              ui: [],
+            },
+            {
+              id: 'alerts_read',
+              name: i18n.translate(
+                'xpack.apm.featureRegistry.subfeature.alertsReadName',
+                {
+                  defaultMessage: 'Read',
+                }
+              ),
+              includeIn: 'read' as 'read',
+              alerting: {
+                alert: {
+                  read: Object.values(AlertType),
                 },
               },
               savedObject: {

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
@@ -13,7 +13,6 @@ import {
   getApmIndexSettings,
 } from '../../lib/settings/apm_indices/get_apm_indices';
 import { saveApmIndices } from '../../lib/settings/apm_indices/save_apm_indices';
-// import { APM_SERVER_FEATURE_ID } from '../../../common/alert_types';
 
 // get list of apm indices and values
 const apmIndexSettingsRoute = createApmServerRoute({
@@ -64,29 +63,7 @@ const saveApmIndicesRoute = createApmServerRoute({
   },
 });
 
-// const getApmAlertsAsDataIndexRoute = createApmServerRoute({
-//   endpoint: 'GET /api/apm/settings/apm-alerts-as-data-indices',
-//   options: { tags: ['access:apm'] },
-//   handler: async (resources) => {
-//     const { context } = resources;
-//     console.error(context);
-//     const alertsAsDataClient = await context.rac?.getAlertsClient();
-//     if (alertsAsDataClient == null) {
-//       throw new Error('Missing alerts as data client');
-//     }
-//     const res = await alertsAsDataClient.getAlertsIndex([
-//       APM_SERVER_FEATURE_ID,
-//       'siem',
-//     ]);
-//     console.error('RESPONSE', JSON.stringify(res, null, 2));
-//     return res[0];
-//     // return alertsAsDataClient.getFullAssetName();
-//     // return ruleDataClient.getIndexName();
-//   },
-// });
-
 export const apmIndicesRouteRepository = createApmServerRouteRepository()
   .add(apmIndexSettingsRoute)
   .add(apmIndicesRoute)
   .add(saveApmIndicesRoute);
-// .add(getApmAlertsAsDataIndexRoute);

--- a/x-pack/plugins/rule_registry/kibana.json
+++ b/x-pack/plugins/rule_registry/kibana.json
@@ -9,6 +9,7 @@
   "requiredPlugins": [
     "alerting",
     "data",
+    "security",
     "spaces",
     "triggersActionsUi"
   ],

--- a/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
@@ -43,6 +43,7 @@ export interface UpdateOptions<Params extends AlertTypeParams> {
 
 interface GetAlertParams {
   id: string;
+  index?: string;
 }
 
 /**
@@ -69,10 +70,13 @@ export class AlertsClient {
     );
   }
 
-  private async fetchAlert({ id }: GetAlertParams): Promise<AlertType> {
+  private async fetchAlert({ id, index }: GetAlertParams): Promise<AlertType> {
     try {
       const result = await this.esClient.search<ParsedTechnicalFields>({
-        index: '.alerts-*',
+        // Context: Originally thought of always just searching `.alerts-*` but that could
+        // result in a big performance hit. If the client already knows which index the alert
+        // belongs to, passing in the index will speed things up
+        index: index ?? '.alerts-*',
         body: { query: { term: { _id: id } } },
       });
 

--- a/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
@@ -11,14 +11,21 @@ import {
   AlertingAuthorization,
   WriteOperations,
   AlertingAuthorizationEntity,
-  // eslint-disable-next-line @kbn/eslint/no-restricted-paths
-} from '../../../alerting/server/authorization';
+} from '../../../alerting/server';
 import { Logger, ElasticsearchClient } from '../../../../../src/core/server';
 import { alertAuditEvent, AlertAuditAction } from './audit_events';
 import { AuditLogger } from '../../../security/server';
-import { OWNER, RULE_ID } from '../../common/technical_rule_data_field_names';
+import { ALERT_STATUS, OWNER, RULE_ID } from '../../common/technical_rule_data_field_names';
 import { ParsedTechnicalFields } from '../../common/parse_technical_fields';
 
+// TODO: Fix typings https://github.com/elastic/kibana/issues/101776
+type NonNullableProps<Obj extends {}, Props extends keyof Obj> = Omit<Obj, Props> &
+  { [K in Props]-?: NonNullable<Obj[K]> };
+type AlertType = NonNullableProps<ParsedTechnicalFields, 'rule.id' | 'kibana.rac.alert.owner'>;
+
+const isValidAlert = (source?: ParsedTechnicalFields): source is AlertType => {
+  return source?.[RULE_ID] != null && source?.[OWNER] != null;
+};
 export interface ConstructorOptions {
   logger: Logger;
   authorization: PublicMethodsOf<AlertingAuthorization>;
@@ -31,14 +38,11 @@ export interface UpdateOptions<Params extends AlertTypeParams> {
   data: {
     status: string;
   };
-  // observability-apm see here: x-pack/plugins/apm/server/plugin.ts:191
   indexName: string;
 }
 
 interface GetAlertParams {
   id: string;
-  // observability-apm see here: x-pack/plugins/apm/server/plugin.ts:191
-  indexName: string;
 }
 
 /**
@@ -60,50 +64,44 @@ export class AlertsClient {
   }
 
   public async getAlertsIndex(featureIds: string[]) {
-    return this.authorization.getAuthorizedAlertsIndices(
+    return this.authorization.getAugmentRuleTypesWithAuthorization(
       featureIds.length !== 0 ? featureIds : ['apm', 'siem']
     );
   }
 
-  // pull concrete index name off of document
-  private async fetchAlert({ id, indexName }: GetAlertParams): Promise<ParsedTechnicalFields> {
+  private async fetchAlert({ id }: GetAlertParams): Promise<AlertType> {
     try {
-      const result = await this.esClient.get<ParsedTechnicalFields>({
-        index: indexName,
-        id,
+      const result = await this.esClient.search<ParsedTechnicalFields>({
+        index: '.alerts-*',
+        body: { query: { term: { _id: id } } },
       });
 
-      if (
-        result.body._source == null ||
-        result.body._source[RULE_ID] == null ||
-        result.body._source[OWNER] == null
-      ) {
-        const errorMessage = `[rac] - Unable to retrieve alert details for alert with id of "${id}".`;
+      if (!isValidAlert(result.body.hits.hits[0]._source)) {
+        const errorMessage = `Unable to retrieve alert details for alert with id of "${id}".`;
         this.logger.debug(errorMessage);
         throw new Error(errorMessage);
       }
 
-      return result.body._source;
+      return result.body.hits.hits[0]._source;
     } catch (error) {
-      const errorMessage = `[rac] - Unable to retrieve alert with id of "${id}".`;
+      const errorMessage = `Unable to retrieve alert with id of "${id}".`;
       this.logger.debug(errorMessage);
       throw error;
     }
   }
 
-  public async get({ id, indexName }: GetAlertParams): Promise<ParsedTechnicalFields> {
+  public async get({ id }: GetAlertParams): Promise<ParsedTechnicalFields> {
     try {
       // first search for the alert by id, then use the alert info to check if user has access to it
       const alert = await this.fetchAlert({
         id,
-        indexName,
       });
 
       // this.authorization leverages the alerting plugin's authorization
       // client exposed to us for reuse
       await this.authorization.ensureAuthorized({
-        ruleTypeId: alert['rule.id']!, // we assert in fetchAlert that these values are non-null
-        consumer: alert['kibana.rac.alert.owner']!, // we assert in fetchAlert that these values are non-null
+        ruleTypeId: alert[RULE_ID],
+        consumer: alert[OWNER],
         operation: ReadOperations.Get,
         entity: AlertingAuthorizationEntity.Alert,
       });
@@ -117,7 +115,7 @@ export class AlertsClient {
 
       return alert;
     } catch (error) {
-      this.logger.debug(`[rac] - Error fetching alert with id of "${id}"`);
+      this.logger.debug(`Error fetching alert with id of "${id}"`);
       this.auditLogger?.log(
         alertAuditEvent({
           action: AlertAuditAction.GET,
@@ -135,15 +133,13 @@ export class AlertsClient {
     indexName,
   }: UpdateOptions<Params>): Promise<ParsedTechnicalFields | null | undefined> {
     try {
-      // TODO: use MGET
       const alert = await this.fetchAlert({
         id,
-        indexName,
       });
 
       await this.authorization.ensureAuthorized({
-        ruleTypeId: alert['rule.id']!, // we assert in fetchAlert that these values are non-null
-        consumer: alert['kibana.rac.alert.owner']!, // we assert in fetchAlert that these values are non-null
+        ruleTypeId: alert[RULE_ID],
+        consumer: alert[OWNER],
         operation: WriteOperations.Update,
         entity: AlertingAuthorizationEntity.Alert,
       });
@@ -153,7 +149,7 @@ export class AlertsClient {
         index: indexName,
         body: {
           doc: {
-            'kibana.rac.alert.status': data.status,
+            [ALERT_STATUS]: data.status,
           },
         },
       };
@@ -180,5 +176,34 @@ export class AlertsClient {
       );
       throw error;
     }
+  }
+
+  public async getAuthorizedAlertsIndices(featureIds: string[]): Promise<string[] | undefined> {
+    const augmentedRuleTypes = await this.authorization.getAugmentRuleTypesWithAuthorization(
+      featureIds
+    );
+
+    const arrayOfAuthorizedRuleTypes = Array.from(augmentedRuleTypes.authorizedRuleTypes);
+
+    // As long as the user can read a minimum of one type of rule type produced by the provided feature,
+    // the user should be provided that features' alerts index.
+    // Limiting which alerts that user can read on that index will be done via the findAuthorizationFilter
+    const authorizedFeatures = arrayOfAuthorizedRuleTypes.reduce(
+      (acc, ruleType) => acc.add(ruleType.producer),
+      new Set<string>()
+    );
+
+    const toReturn = Array.from(authorizedFeatures).flatMap((feature) => {
+      switch (feature) {
+        case 'apm':
+          return '.alerts-observability-apm';
+        case 'siem':
+          return ['.alerts-security-solution', '.siem-signals'];
+        default:
+          return [];
+      }
+    });
+
+    return toReturn;
   }
 }

--- a/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client_factory.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client_factory.ts
@@ -8,8 +8,7 @@
 import { ElasticsearchClient, KibanaRequest, Logger } from 'src/core/server';
 import { PublicMethodsOf } from '@kbn/utility-types';
 import { SecurityPluginSetup } from '../../../security/server';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { AlertingAuthorization } from '../../../alerting/server/authorization';
+import { AlertingAuthorization } from '../../../alerting/server';
 import { AlertsClient } from './alerts_client';
 
 export interface AlertsClientFactoryProps {

--- a/x-pack/plugins/rule_registry/server/alert_data_client/tests/update.test.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/tests/update.test.ts
@@ -103,6 +103,60 @@ describe('update()', () => {
         },
       ]
     `);
+  });
+
+  test('logs successful event in audit logger', async () => {
+    const alertsClient = new AlertsClient(alertsClientParams);
+    esClientMock.get.mockResolvedValueOnce(
+      elasticsearchClientMock.createApiResponse({
+        body: {
+          found: true,
+          _type: 'alert',
+          _index: '.alerts-observability-apm',
+          _id: 'NoxgpHkBqbdrfX07MqXV',
+          _source: {
+            'rule.id': 'apm.error_rate',
+            message: 'hello world 1',
+            'kibana.rac.alert.owner': 'apm',
+            'kibana.rac.alert.status': 'open',
+          },
+        },
+      })
+    );
+    esClientMock.update.mockResolvedValueOnce(
+      elasticsearchClientMock.createApiResponse({
+        body: {
+          _primary_term: 2,
+          result: 'updated',
+          _seq_no: 1,
+          _shards: {
+            failed: 0,
+            successful: 1,
+            total: 1,
+          },
+          _version: 1,
+          _index: '.alerts-observability-apm',
+          _id: 'NoxgpHkBqbdrfX07MqXV',
+          get: {
+            found: true,
+            _seq_no: 1,
+            _primary_term: 2,
+            _source: {
+              'rule.id': 'apm.error_rate',
+              message: 'hello world 1',
+              'kibana.rac.alert.owner': 'apm',
+              'kibana.rac.alert.status': 'closed',
+            },
+          },
+        },
+      })
+    );
+    await alertsClient.update({
+      id: '1',
+      data: { status: 'closed' },
+      indexName: '.alerts-observability-apm',
+    });
+
     expect(auditLogger.log).toHaveBeenCalledWith({
       error: undefined,
       event: {
@@ -116,7 +170,7 @@ describe('update()', () => {
   });
 
   test(`throws an error if ES client get fails`, async () => {
-    const error = new Error('something when wrong on get');
+    const error = new Error('something went wrong on get');
     const alertsClient = new AlertsClient(alertsClientParams);
     esClientMock.get.mockRejectedValue(error);
 
@@ -126,9 +180,9 @@ describe('update()', () => {
         data: { status: 'closed' },
         indexName: '.alerts-observability-apm',
       })
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"something when wrong on get"`);
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"something went wrong on get"`);
     expect(auditLogger.log).toHaveBeenCalledWith({
-      error: { code: 'Error', message: 'something when wrong on get' },
+      error: { code: 'Error', message: 'something went wrong on get' },
       event: {
         action: 'alert_update',
         category: ['database'],
@@ -140,7 +194,7 @@ describe('update()', () => {
   });
 
   test(`throws an error if ES client update fails`, async () => {
-    const error = new Error('something when wrong on update');
+    const error = new Error('something went wrong on update');
     const alertsClient = new AlertsClient(alertsClientParams);
     esClientMock.get.mockResolvedValueOnce(
       elasticsearchClientMock.createApiResponse({
@@ -166,9 +220,9 @@ describe('update()', () => {
         data: { status: 'closed' },
         indexName: '.alerts-observability-apm',
       })
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"something when wrong on update"`);
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"something went wrong on update"`);
     expect(auditLogger.log).toHaveBeenCalledWith({
-      error: { code: 'Error', message: 'something when wrong on update' },
+      error: { code: 'Error', message: 'something went wrong on update' },
       event: {
         action: 'alert_update',
         category: ['database'],

--- a/x-pack/plugins/rule_registry/server/plugin.ts
+++ b/x-pack/plugins/rule_registry/server/plugin.ts
@@ -114,12 +114,6 @@ export class RuleRegistryPlugin
     );
 
     defineRoutes(router);
-    // handler is called when '/path' resource is requested with `GET` method
-    router.get({ path: '/rac-myfakepath', validate: false }, async (context, req, res) => {
-      const racClient = await context.rac.getAlertsClient();
-      racClient?.get({ id: 'hello world', indexName: '.alerts-observability-apm' });
-      return res.ok();
-    });
 
     const eventLogService = new EventLogService({
       config: {

--- a/x-pack/plugins/rule_registry/server/routes/__mocks__/request_context.ts
+++ b/x-pack/plugins/rule_registry/server/routes/__mocks__/request_context.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock, elasticsearchServiceMock, savedObjectsClientMock } from 'src/core/server/mocks';
+import { alertsClientMock } from '../../alert_data_client/alerts_client.mock';
+import { RacRequestHandlerContext } from '../../types';
+
+const createMockClients = () => ({
+  rac: alertsClientMock.create(),
+  clusterClient: elasticsearchServiceMock.createLegacyScopedClusterClient(),
+  newClusterClient: elasticsearchServiceMock.createScopedClusterClient(),
+  savedObjectsClient: savedObjectsClientMock.create(),
+});
+
+const createRequestContextMock = (
+  clients: ReturnType<typeof createMockClients> = createMockClients()
+) => {
+  const coreContext = coreMock.createRequestHandlerContext();
+  return ({
+    rac: { getAlertsClient: jest.fn(() => clients.rac) },
+    core: {
+      ...coreContext,
+      elasticsearch: {
+        ...coreContext.elasticsearch,
+        client: clients.newClusterClient,
+        legacy: { ...coreContext.elasticsearch.legacy, client: clients.clusterClient },
+      },
+      savedObjects: { client: clients.savedObjectsClient },
+    },
+  } as unknown) as RacRequestHandlerContext;
+};
+
+const createTools = () => {
+  const clients = createMockClients();
+  const context = createRequestContextMock(clients);
+
+  return { clients, context };
+};
+
+export const requestContextMock = {
+  create: createRequestContextMock,
+  createMockClients,
+  createTools,
+};

--- a/x-pack/plugins/rule_registry/server/routes/__mocks__/request_responses.ts
+++ b/x-pack/plugins/rule_registry/server/routes/__mocks__/request_responses.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BASE_RAC_ALERTS_API_PATH } from '../../../common/constants';
+import { requestMock } from './server';
+
+export const getReadRequest = () =>
+  requestMock.create({
+    method: 'get',
+    path: BASE_RAC_ALERTS_API_PATH,
+    query: { id: 'alert-1' },
+  });
+
+export const getUpdateRequest = () =>
+  requestMock.create({
+    method: 'patch',
+    path: BASE_RAC_ALERTS_API_PATH,
+    body: {
+      status: 'closed',
+      ids: ['alert-1'],
+      indexName: '.alerts-observability-apm*',
+    },
+  });

--- a/x-pack/plugins/rule_registry/server/routes/__mocks__/response_adapters.ts
+++ b/x-pack/plugins/rule_registry/server/routes/__mocks__/response_adapters.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from 'src/core/server/mocks';
+
+const responseMock = {
+  create: httpServerMock.createResponseFactory,
+};
+
+type ResponseMock = ReturnType<typeof responseMock.create>;
+type Method = keyof ResponseMock;
+
+type MockCall = any;
+
+interface ResponseCall {
+  body: any;
+  status: number;
+}
+
+/**
+ * @internal
+ */
+export interface Response extends ResponseCall {
+  calls: ResponseCall[];
+}
+
+const buildResponses = (method: Method, calls: MockCall[]): ResponseCall[] => {
+  if (!calls.length) return [];
+
+  switch (method) {
+    case 'ok':
+      return calls.map(([call]) => ({ status: 200, body: call.body }));
+    case 'custom':
+      return calls.map(([call]) => ({
+        status: call.statusCode,
+        body: JSON.parse(call.body),
+      }));
+    default:
+      throw new Error(`Encountered unexpected call to response.${method}`);
+  }
+};
+
+export const responseAdapter = (response: ResponseMock): Response => {
+  const methods = Object.keys(response) as Method[];
+  const calls = methods
+    .reduce<Response['calls']>((responses, method) => {
+      const methodMock = response[method];
+      return [...responses, ...buildResponses(method, methodMock.mock.calls)];
+    }, [])
+    .sort((call, other) => other.status - call.status);
+
+  const [{ body, status }] = calls;
+
+  return {
+    body,
+    status,
+    calls,
+  };
+};

--- a/x-pack/plugins/rule_registry/server/routes/__mocks__/server.ts
+++ b/x-pack/plugins/rule_registry/server/routes/__mocks__/server.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RequestHandler, RouteConfig, KibanaRequest } from 'src/core/server';
+import { httpServerMock, httpServiceMock } from 'src/core/server/mocks';
+import { RacRequestHandlerContext } from '../../types';
+import { requestContextMock } from './request_context';
+import { responseAdapter } from './response_adapters';
+
+export const requestMock = {
+  create: httpServerMock.createKibanaRequest,
+};
+
+export const responseFactoryMock = {
+  create: httpServerMock.createResponseFactory,
+};
+
+interface Route {
+  config: RouteConfig<unknown, unknown, unknown, 'get' | 'post' | 'delete' | 'patch' | 'put'>;
+  handler: RequestHandler;
+}
+const getRoute = (routerMock: MockServer['router']): Route => {
+  const routeCalls = [
+    ...routerMock.get.mock.calls,
+    ...routerMock.post.mock.calls,
+    ...routerMock.put.mock.calls,
+    ...routerMock.patch.mock.calls,
+    ...routerMock.delete.mock.calls,
+  ];
+
+  const [route] = routeCalls;
+  if (!route) {
+    throw new Error('No route registered!');
+  }
+
+  const [config, handler] = route;
+  return { config, handler };
+};
+
+const buildResultMock = () => ({ ok: jest.fn((x) => x), badRequest: jest.fn((x) => x) });
+
+class MockServer {
+  constructor(
+    public readonly router = httpServiceMock.createRouter(),
+    private responseMock = responseFactoryMock.create(),
+    private contextMock = requestContextMock.create(),
+    private resultMock = buildResultMock()
+  ) {}
+
+  public validate(request: KibanaRequest) {
+    this.validateRequest(request);
+    return this.resultMock;
+  }
+
+  public async inject(
+    request: KibanaRequest,
+    context: RacRequestHandlerContext = this.contextMock
+  ) {
+    const validatedRequest = this.validateRequest(request);
+    const [rejection] = this.resultMock.badRequest.mock.calls;
+    if (rejection) {
+      throw new Error(`Request was rejected with message: '${rejection}'`);
+    }
+
+    await this.getRoute().handler(context, validatedRequest, this.responseMock);
+    return responseAdapter(this.responseMock);
+  }
+
+  private getRoute(): Route {
+    return getRoute(this.router);
+  }
+
+  private maybeValidate(part: any, validator?: any): any {
+    return typeof validator === 'function' ? validator(part, this.resultMock) : part;
+  }
+
+  private validateRequest(request: KibanaRequest): KibanaRequest {
+    const validations = this.getRoute().config.validate;
+    if (!validations) {
+      return request;
+    }
+
+    const validatedRequest = requestMock.create({
+      path: request.route.path,
+      method: request.route.method,
+      body: this.maybeValidate(request.body, validations.body),
+      query: this.maybeValidate(request.query, validations.query),
+      params: this.maybeValidate(request.params, validations.params),
+    });
+
+    return validatedRequest;
+  }
+}
+
+const createMockServer = () => new MockServer();
+
+export const serverMock = {
+  create: createMockServer,
+};

--- a/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.test.ts
+++ b/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BASE_RAC_ALERTS_API_PATH } from '../../common/constants';
+import { getAlertByIdRoute } from './get_alert_by_id';
+import { requestContextMock } from './__mocks__/request_context';
+import { getReadRequest } from './__mocks__/request_responses';
+import { requestMock, serverMock } from './__mocks__/server';
+
+const getMockAlert = () => ({
+  type: 'doc',
+  value: {
+    index: '.alerts-observability-apm',
+    id: 'alert-id',
+    source: {
+      'rule.id': 'apm.error_rate',
+      message: 'hello world 1',
+      'kibana.rac.alert.owner': 'apm',
+      'kibana.rac.alert.status': 'open',
+    },
+  },
+});
+
+describe('getAlertByIdRoute', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let { clients, context } = requestContextMock.createTools();
+
+  beforeEach(async () => {
+    server = serverMock.create();
+    ({ clients, context } = requestContextMock.createTools());
+
+    clients.rac.get.mockResolvedValue(getMockAlert());
+
+    getAlertByIdRoute(server.router);
+  });
+
+  test('returns 200 when finding a single alert with valid params', async () => {
+    const response = await server.inject(getReadRequest(), context);
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual(getMockAlert());
+  });
+
+  describe('request validation', () => {
+    test('rejects invalid query params', async () => {
+      await expect(
+        server.inject(
+          requestMock.create({
+            method: 'get',
+            path: BASE_RAC_ALERTS_API_PATH,
+            query: { id: 4 },
+          }),
+          context
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Request was rejected with message: 'Invalid value \\"4\\" supplied to \\"id\\"'"`
+      );
+    });
+
+    test('rejects unknown query params', async () => {
+      await expect(
+        server.inject(
+          requestMock.create({
+            method: 'get',
+            path: BASE_RAC_ALERTS_API_PATH,
+            query: { notId: 4 },
+          }),
+          context
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Request was rejected with message: 'Invalid value \\"undefined\\" supplied to \\"id\\"'"`
+      );
+    });
+  });
+
+  test('returns error status if rac client "GET" fails', async () => {
+    clients.rac.get.mockRejectedValue(new Error('Unable to get alert'));
+    const response = await server.inject(getReadRequest(), context);
+
+    expect(response.status).toEqual(500);
+    expect(response.body).toEqual({ message: 'Unable to get alert', status_code: 500 });
+  });
+});

--- a/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.test.ts
+++ b/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.test.ts
@@ -45,6 +45,20 @@ describe('getAlertByIdRoute', () => {
     expect(response.body).toEqual(getMockAlert());
   });
 
+  test('returns 200 when finding a single alert with index param', async () => {
+    const response = await server.inject(
+      requestMock.create({
+        method: 'get',
+        path: BASE_RAC_ALERTS_API_PATH,
+        query: { id: 'alert-1', index: '.alerts-me' },
+      }),
+      context
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual(getMockAlert());
+  });
+
   describe('request validation', () => {
     test('rejects invalid query params', async () => {
       await expect(

--- a/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.ts
+++ b/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.ts
@@ -23,7 +23,6 @@ export const getAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) => 
           t.exact(
             t.type({
               id: _id,
-              indexName: t.string,
             })
           )
         ),
@@ -35,8 +34,8 @@ export const getAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) => 
     async (context, request, response) => {
       try {
         const alertsClient = await context.rac.getAlertsClient();
-        const { id, indexName } = request.query;
-        const alert = await alertsClient.get({ id, indexName });
+        const { id } = request.query;
+        const alert = await alertsClient.get({ id });
         return response.ok({
           body: alert,
         });
@@ -59,7 +58,6 @@ export const getAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) => 
             })
           ),
         });
-        // return response.custom;
       }
     }
   );

--- a/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.ts
+++ b/x-pack/plugins/rule_registry/server/routes/get_alert_by_id.ts
@@ -20,11 +20,18 @@ export const getAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) => 
       path: BASE_RAC_ALERTS_API_PATH,
       validate: {
         query: buildRouteValidation(
-          t.exact(
-            t.type({
-              id: _id,
-            })
-          )
+          t.intersection([
+            t.exact(
+              t.type({
+                id: _id,
+              })
+            ),
+            t.exact(
+              t.partial({
+                index: t.string,
+              })
+            ),
+          ])
         ),
       },
       options: {
@@ -34,8 +41,8 @@ export const getAlertByIdRoute = (router: IRouter<RacRequestHandlerContext>) => 
     async (context, request, response) => {
       try {
         const alertsClient = await context.rac.getAlertsClient();
-        const { id } = request.query;
-        const alert = await alertsClient.get({ id });
+        const { id, index } = request.query;
+        const alert = await alertsClient.get({ id, index });
         return response.ok({
           body: alert,
         });

--- a/x-pack/plugins/rule_registry/server/routes/update_alert_by_id.test.ts
+++ b/x-pack/plugins/rule_registry/server/routes/update_alert_by_id.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BASE_RAC_ALERTS_API_PATH } from '../../common/constants';
+import { updateAlertByIdRoute } from './update_alert_by_id';
+import { requestContextMock } from './__mocks__/request_context';
+import { getUpdateRequest } from './__mocks__/request_responses';
+import { requestMock, serverMock } from './__mocks__/server';
+
+const getMockAlert = () => ({
+  type: 'doc',
+  value: {
+    index: '.alerts-observability-apm',
+    id: 'alert-id',
+    source: {
+      'rule.id': 'apm.error_rate',
+      message: 'hello world 1',
+      'kibana.rac.alert.owner': 'apm',
+      'kibana.rac.alert.status': 'open',
+    },
+  },
+});
+
+describe('updateAlertByIdRoute', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let { clients, context } = requestContextMock.createTools();
+
+  beforeEach(async () => {
+    server = serverMock.create();
+    ({ clients, context } = requestContextMock.createTools());
+
+    clients.rac.update.mockResolvedValue({
+      ...getMockAlert().value.source,
+      'kibana.rac.alert.status': 'closed',
+    });
+
+    updateAlertByIdRoute(server.router);
+  });
+
+  test('returns 200 when updating a single alert with valid params', async () => {
+    const response = await server.inject(getUpdateRequest(), context);
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      alerts: {
+        ...getMockAlert().value.source,
+        'kibana.rac.alert.status': 'closed',
+      },
+      success: true,
+    });
+  });
+
+  describe('request validation', () => {
+    test('rejects invalid query params', async () => {
+      await expect(
+        server.inject(
+          requestMock.create({
+            method: 'patch',
+            path: BASE_RAC_ALERTS_API_PATH,
+            body: {
+              status: 'closed',
+              ids: 'alert-1',
+              indexName: '.alerts-observability-apm*',
+            },
+          }),
+          context
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Request was rejected with message: 'Invalid value \\"alert-1\\" supplied to \\"ids\\"'"`
+      );
+    });
+
+    test('rejects unknown query params', async () => {
+      await expect(
+        server.inject(
+          requestMock.create({
+            method: 'patch',
+            path: BASE_RAC_ALERTS_API_PATH,
+            body: {
+              notStatus: 'closed',
+              ids: ['alert-1'],
+              indexName: '.alerts-observability-apm*',
+            },
+          }),
+          context
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Request was rejected with message: 'Invalid value \\"undefined\\" supplied to \\"status\\"'"`
+      );
+    });
+  });
+
+  test('returns error status if rac client "GET" fails', async () => {
+    clients.rac.update.mockRejectedValue(new Error('Unable to update alert'));
+    const response = await server.inject(getUpdateRequest(), context);
+
+    expect(response.status).toEqual(500);
+    expect(response.body).toEqual({ message: 'Unable to update alert', status_code: 500 });
+  });
+});

--- a/x-pack/plugins/rule_registry/server/rule_data_plugin_service/index.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_plugin_service/index.ts
@@ -16,7 +16,6 @@ import {
 import { ecsComponentTemplate } from '../../common/assets/component_templates/ecs_component_template';
 import { defaultLifecyclePolicy } from '../../common/assets/lifecycle_policies/default_lifecycle_policy';
 import { ClusterPutComponentTemplateBody, PutIndexTemplateRequest } from '../../common/types';
-// import { ClusterClient } from 'src/core/server/elasticsearch/client';
 
 const BOOTSTRAP_TIMEOUT = 60000;
 
@@ -157,7 +156,6 @@ export class RuleDataPluginService {
   }
 
   getFullAssetName(assetName?: string) {
-    // return [this.options.index, assetName].filter(Boolean).join('-');
     return [this.fullAssetName, assetName].filter(Boolean).join('-');
   }
 

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type_factory.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type_factory.ts
@@ -75,8 +75,6 @@ export const createLifecycleRuleTypeFactory: CreateLifecycleRuleTypeFactory = ({
 
       const ruleExecutorData = getRuleExecutorData(type, options);
 
-      logger.debug(`LOGGER RULE REGISTRY CONSUMER ${rule.consumer}`);
-
       const decodedState = wrappedStateRt.decode(previousState);
 
       const state = isLeft(decodedState)
@@ -225,10 +223,8 @@ export const createLifecycleRuleTypeFactory: CreateLifecycleRuleTypeFactory = ({
         return event;
       });
 
-      logger.debug(`LOGGER EVENTSTOINDEX: ${JSON.stringify(eventsToIndex, null, 2)}`);
-
       if (eventsToIndex.length) {
-        logger.debug('LOGGER ABOUT TO INDEX ALERTS');
+        logger.debug(`Preparing to index ${eventsToIndex.length} alerts.`);
 
         await ruleDataClient.getWriter().bulk({
           body: eventsToIndex.flatMap((event) => [{ index: {} }, event]),

--- a/x-pack/plugins/rule_registry/tsconfig.json
+++ b/x-pack/plugins/rule_registry/tsconfig.json
@@ -19,6 +19,7 @@
     { "path": "../../../src/core/tsconfig.json" },
     { "path": "../../../src/plugins/data/tsconfig.json" },
     { "path": "../alerting/tsconfig.json" },
+    { "path": "../security/tsconfig.json" },
     { "path": "../spaces/tsconfig.json" },
     { "path": "../triggers_actions_ui/tsconfig.json" }
   ]

--- a/x-pack/test/rule_registry/common/config.ts
+++ b/x-pack/test/rule_registry/common/config.ts
@@ -54,42 +54,6 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
       },
     };
 
-    // Find all folders in ./fixtures/plugins
-    // const allFiles = fs.readdirSync(path.resolve(__dirname, 'fixtures', 'plugins'));
-    // const plugins = allFiles.filter((file) =>
-    //   fs.statSync(path.resolve(__dirname, 'fixtures', 'plugins', file)).isDirectory()
-    // );
-
-    // This is needed so that we can correctly use the alerting test frameworks mock implementation for the connectors.
-    // const alertingAllFiles = fs.readdirSync(
-    //   path.resolve(
-    //     __dirname,
-    //     '..',
-    //     '..',
-    //     'alerting_api_integration',
-    //     'common',
-    //     'fixtures',
-    //     'plugins'
-    //   )
-    // );
-
-    // const alertingPlugins = alertingAllFiles.filter((file) =>
-    //   fs
-    //     .statSync(
-    //       path.resolve(
-    //         __dirname,
-    //         '..',
-    //         '..',
-    //         'alerting_api_integration',
-    //         'common',
-    //         'fixtures',
-    //         'plugins',
-    //         file
-    //       )
-    //     )
-    //     .isDirectory()
-    // );
-
     return {
       testFiles: testFiles ? testFiles : [require.resolve('../tests/common')],
       servers,
@@ -117,24 +81,6 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
           `--xpack.actions.enabledActionTypes=${JSON.stringify(enabledActionTypes)}`,
           '--xpack.eventLog.logEntries=true',
           ...disabledPlugins.map((key) => `--xpack.${key}.enabled=false`),
-          // Actions simulators plugin. Needed for testing push to external services.
-          // ...alertingPlugins.map(
-          //   (pluginDir) =>
-          //     `--plugin-path=${path.resolve(
-          //       __dirname,
-          //       '..',
-          //       '..',
-          //       'alerting_api_integration',
-          //       'common',
-          //       'fixtures',
-          //       'plugins',
-          //       pluginDir
-          //     )}`
-          // ),
-          // ...plugins.map(
-          //   (pluginDir) =>
-          //     `--plugin-path=${path.resolve(__dirname, 'fixtures', 'plugins', pluginDir)}`
-          // ),
           `--server.xsrf.whitelist=${JSON.stringify(getAllExternalServiceSimulatorPaths())}`,
           ...(ssl
             ? [

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/update_alert.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/update_alert.ts
@@ -56,14 +56,7 @@ export default ({ getService }: FtrProviderContext) => {
           .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', indexName: apmIndex })
           .expect(200);
       });
-      // it(`${globalRead.username} should be able to access the APM alert in ${SPACE1}`, async () => {
-      //   const res = await supertestWithoutAuth
-      //     .get(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}?id=NoxgpHkBqbdrfX07MqXV`)
-      //     .auth(globalRead.username, globalRead.password)
-      //     .set('kbn-xsrf', 'true')
-      //     .expect(200);
-      //   // console.error('RES', res);
-      // });
+
       it(`${obsOnlySpacesAll.username} should be able to update the APM alert in ${SPACE1}`, async () => {
         const apmIndex = await getAPMIndexName(superUser);
         await supertestWithoutAuth
@@ -109,62 +102,5 @@ export default ({ getService }: FtrProviderContext) => {
         });
       }
     });
-
-    // describe('Space:', () => {
-    //   for (const scenario of [
-    //     { user: superUser, space: SPACE1 },
-    //     { user: globalRead, space: SPACE1 },
-    //   ]) {
-    //     it(`${scenario.user.username} should be able to access the APM alert in ${SPACE2}`, async () => {
-    //       await supertestWithoutAuth
-    //         .get(`${getSpaceUrlPrefix(SPACE2)}${TEST_URL}?id=NoxgpHkBqbdrfX07MqXV`)
-    //         .auth(scenario.user.username, scenario.user.password)
-    //         .set('kbn-xsrf', 'true')
-    //         .expect(200);
-    //     });
-    //   }
-
-    //   for (const scenario of [
-    //     { user: secOnly },
-    //     { user: secOnlyRead },
-    //     { user: obsSec },
-    //     { user: obsSecRead },
-    //     {
-    //       user: noKibanaPrivileges,
-    //     },
-    //     {
-    //       user: obsOnly,
-    //     },
-    //     {
-    //       user: obsOnlyRead,
-    //     },
-    //   ]) {
-    //     it(`${scenario.user.username} with right to access space1 only, should not be able to access the APM alert in ${SPACE2}`, async () => {
-    //       await supertestWithoutAuth
-    //         .get(`${getSpaceUrlPrefix(SPACE2)}${TEST_URL}?id=NoxgpHkBqbdrfX07MqXV`)
-    //         .auth(scenario.user.username, scenario.user.password)
-    //         .set('kbn-xsrf', 'true')
-    //         .expect(403);
-    //     });
-    //   }
-    // });
-
-    // describe('extra params', () => {
-    //   it('should NOT allow to pass a filter query parameter', async () => {
-    //     await supertest
-    //       .get(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}?sortOrder=asc&namespaces[0]=*`)
-    //       .set('kbn-xsrf', 'true')
-    //       .send()
-    //       .expect(400);
-    //   });
-
-    //   it('should NOT allow to pass a non supported query parameter', async () => {
-    //     await supertest
-    //       .get(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}?notExists=something`)
-    //       .set('kbn-xsrf', 'true')
-    //       .send()
-    //       .expect(400);
-    //   });
-    // });
   });
 };


### PR DESCRIPTION
WIP - trying to fix integration tests, broken authz for observer user / role

updates authz feature builder to what ying had before we messed it up in our branch

fixes integration tests

add rac api access to apm

adds getIndex functionality which requires the asset name to be passed in, same style as in the rule registry data client, adds update integration tests

fix small merge conflict and update shell script

fix merge conflict in alerting test file

fix most type errors

fix the rest of the type failures

fix integration tests

fix integration tests

fix type error with feature registration in apm

fix integration tests in apm and security solution

fix type checker

fix jest tests for apm

remove console.error statements for eslint

fix type check

update security solution jest tests

cleaning up PR and adding basic unit tests

still need to clean up types in tests and update one test file

fixes snapshot for signals template

fix tests

fix type check failures

update cypress test

undo changes in alert authz class, updates alert privilege in apm feature to 'read', utilizes the 'rule' object available in executor params over querying for the rule SO directly

remove verbose logging from detection api integration tests

fix type

fix jest tests, adds missing mocked rule object to alert executor params

[RAC] [RBAC] adds function to get alerts-as-data index name (#6)

* WIP - test script and route in rule registry to pull index name. I need to test out adding this route within the APM and sec sol plugins specifically and see if they spit back the same .alerts index but with the appropriate asset name despite not providing one.

WIP - DO NOT DELETE THIS CODE

minor cleanup

updates client to require passing in index name, which is now available through the alerts as data client function getAlertsIndex

fix types

* remove outdated comment

update README, adds integration test (skipped) for testing authz with search strategy (#8)

* WIP

* update README, adds integration test (skipped) for testing authz with search strategy

* fix rebase issues

* adds typedoc docs

* adds SKIPPED integration test for timeline search strategy to be unskipped once authorization is added to search strategy

* removes unused references to the rule data client within the rule registry## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
