### PR TITLE
removes reference to esArchiver key in config and updates path of esArchiver data

### DIFF
--- a/x-pack/test/rule_registry/common/config.ts
+++ b/x-pack/test/rule_registry/common/config.ts
@@ -61,7 +61,6 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
       junit: {
         reportName: 'X-Pack Case API Integration Tests',
       },
-      esArchiver: xPackApiIntegrationTestsConfig.get('esArchiver'),
       esTestCluster: {
         ...xPackApiIntegrationTestsConfig.get('esTestCluster'),
         license,

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts.ts
@@ -52,7 +52,7 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('rbac', () => {
     before(async () => {
-      await esArchiver.load('rule_registry/alerts');
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_registry/alerts');
     });
     describe('Users:', () => {
       it(`${superUser.username} should be able to access the APM alert in ${SPACE1}`, async () => {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/update_alert.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/update_alert.ts
@@ -45,10 +45,10 @@ export default ({ getService }: FtrProviderContext) => {
   describe('rbac', () => {
     describe('Users update:', () => {
       beforeEach(async () => {
-        await esArchiver.load('rule_registry/alerts');
+        await esArchiver.load('x-pack/test/functional/es_archives/rule_registry/alerts');
       });
       afterEach(async () => {
-        await esArchiver.unload('rule_registry/alerts');
+        await esArchiver.unload('x-pack/test/functional/es_archives/rule_registry/alerts');
       });
       it(`${superUser.username} should be able to update the APM alert in ${SPACE1}`, async () => {
         const apmIndex = await getAPMIndexName(superUser);
@@ -56,7 +56,7 @@ export default ({ getService }: FtrProviderContext) => {
           .post(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}`)
           .auth(superUser.username, superUser.password)
           .set('kbn-xsrf', 'true')
-          .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', indexName: apmIndex })
+          .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', index: apmIndex })
           .expect(200);
       });
 
@@ -66,7 +66,7 @@ export default ({ getService }: FtrProviderContext) => {
           .post(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}`)
           .auth(obsOnlySpacesAll.username, obsOnlySpacesAll.password)
           .set('kbn-xsrf', 'true')
-          .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', indexName: apmIndex })
+          .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', index: apmIndex })
           .expect(200);
       });
       it(`${obsOnlyReadSpacesAll.username} should NOT be able to update the APM alert in ${SPACE1}`, async () => {
@@ -75,7 +75,7 @@ export default ({ getService }: FtrProviderContext) => {
           .post(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}`)
           .auth(obsOnlyReadSpacesAll.username, obsOnlyReadSpacesAll.password)
           .set('kbn-xsrf', 'true')
-          .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', indexName: apmIndex })
+          .send({ ids: ['NoxgpHkBqbdrfX07MqXV'], status: 'closed', index: apmIndex })
           .expect(403);
       });
 
@@ -99,7 +99,7 @@ export default ({ getService }: FtrProviderContext) => {
             .send({
               ids: ['NoxgpHkBqbdrfX07MqXV'],
               status: 'closed',
-              indexName: apmIndex,
+              index: apmIndex,
             })
             .expect(403);
         });


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
