### PR TITLE
POC. Execution history on Alerting v2

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/constants.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const RULE_EXECUTOR_EVENT_PROVIDER = 'alerting_v2' as const;
+
+export const RULE_EXECUTOR_EVENT_ACTIONS = {
+  EXECUTE_START: 'execute-start',
+  EXECUTE: 'execute',
+} as const;
+
+export type RuleExecutorEventAction =
+  (typeof RULE_EXECUTOR_EVENT_ACTIONS)[keyof typeof RULE_EXECUTOR_EVENT_ACTIONS];

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/task_runner.test.ts
@@ -12,10 +12,12 @@ import { RuleExecutorTaskRunner } from './task_runner';
 import type { RuleExecutionPipelineContract } from './execution_pipeline';
 import { createRulePipelineState } from './test_utils';
 import { createLoggerService } from '../services/logger_service/logger_service.mock';
+import type { EventLogServiceContract } from '../services/event_log_service/event_log_service';
 
 describe('RuleExecutorTaskRunner', () => {
   let runner: RuleExecutorTaskRunner;
   let pipeline: jest.Mocked<RuleExecutionPipelineContract>;
+  let eventLogService: jest.Mocked<EventLogServiceContract>;
   let abortController: AbortController;
 
   // @ts-expect-error: not all fields are required
@@ -29,8 +31,13 @@ describe('RuleExecutorTaskRunner', () => {
 
   beforeEach(() => {
     pipeline = { execute: jest.fn() };
+    eventLogService = { logEvent: jest.fn() };
     const mockLoggerService = createLoggerService();
-    runner = new RuleExecutorTaskRunner(pipeline, mockLoggerService.loggerService);
+    runner = new RuleExecutorTaskRunner(
+      pipeline,
+      mockLoggerService.loggerService,
+      eventLogService
+    );
     abortController = new AbortController();
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/task_runner.ts
@@ -8,6 +8,9 @@
 import type { RunContext, RunResult } from '@kbn/task-manager-plugin/server/task';
 import { throwUnrecoverableError } from '@kbn/task-manager-plugin/server';
 import { inject, injectable } from 'inversify';
+import { v4 as uuidV4 } from 'uuid';
+import type { IEvent } from '@kbn/event-log-plugin/server';
+import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 
 import type { HaltReason, RuleExecutorTaskParams } from './types';
 import type {
@@ -20,6 +23,10 @@ import {
   LoggerServiceToken,
   type LoggerServiceContract,
 } from '../services/logger_service/logger_service';
+import { EventLogServiceToken } from '../services/event_log_service/tokens';
+import type { EventLogServiceContract } from '../services/event_log_service/event_log_service';
+import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
+import { RULE_EXECUTOR_EVENT_ACTIONS } from './constants';
 
 type TaskRunParams = Pick<RunContext, 'taskInstance' | 'abortController'>;
 
@@ -27,13 +34,58 @@ type TaskRunParams = Pick<RunContext, 'taskInstance' | 'abortController'>;
 export class RuleExecutorTaskRunner {
   constructor(
     @inject(RuleExecutionPipeline) private readonly pipeline: RuleExecutionPipelineContract,
-    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract
+    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
+    @inject(EventLogServiceToken) private readonly eventLogService: EventLogServiceContract
   ) {}
 
   public async run({ taskInstance, abortController }: TaskRunParams): Promise<RunResult> {
     const input = this.createRuleExecutionInput(taskInstance, abortController);
+    const params = taskInstance.params as RuleExecutorTaskParams;
+    const executionUuid = uuidV4();
+    const startTime = Date.now();
+    const startTimeIso = new Date(startTime).toISOString();
+    const scheduleDelay = taskInstance.startedAt
+      ? startTime - new Date(taskInstance.scheduledAt ?? taskInstance.startedAt).getTime()
+      : 0;
 
-    const result = await this.pipeline.execute(input);
+    this.emitExecuteStart({
+      executionUuid,
+      timestamp: startTimeIso,
+      ruleId: params.ruleId,
+      spaceId: params.spaceId,
+    });
+
+    let result: RuleExecutionPipelineResult;
+    let executionError: Error | undefined;
+
+    try {
+      result = await this.pipeline.execute(input);
+    } catch (err) {
+      executionError = err instanceof Error ? err : new Error(String(err));
+      result = {
+        completed: false,
+        finalState: { input: { ...input, executionContext: undefined as never } },
+      };
+    }
+
+    const endTime = Date.now();
+    const durationMs = endTime - startTime;
+
+    this.emitExecute({
+      executionUuid,
+      startTimeIso,
+      endTimeIso: new Date(endTime).toISOString(),
+      durationNs: durationMs * 1_000_000,
+      scheduleDelayNs: scheduleDelay * 1_000_000,
+      ruleId: params.ruleId,
+      spaceId: params.spaceId,
+      result,
+      error: executionError,
+    });
+
+    if (executionError) {
+      throw executionError;
+    }
 
     return this.buildRunResult(result, taskInstance);
   }
@@ -102,6 +154,147 @@ export class RuleExecutorTaskRunner {
         return taskInstance.state ?? {};
       default:
         return {};
+    }
+  }
+
+  private emitExecuteStart({
+    executionUuid,
+    timestamp,
+    ruleId,
+    spaceId,
+  }: {
+    executionUuid: string;
+    timestamp: string;
+    ruleId: string;
+    spaceId: string;
+  }): void {
+    const event: IEvent = {
+      '@timestamp': timestamp,
+      event: {
+        action: RULE_EXECUTOR_EVENT_ACTIONS.EXECUTE_START,
+        kind: 'event',
+      },
+      kibana: {
+        saved_objects: [
+          {
+            type: RULE_SAVED_OBJECT_TYPE,
+            id: ruleId,
+            rel: SAVED_OBJECT_REL_PRIMARY,
+            namespace: spaceId === 'default' ? undefined : spaceId,
+          },
+        ],
+        space_ids: [spaceId],
+        alerting_v2: {
+          rule_executor: {
+            execution: {
+              uuid: executionUuid,
+            },
+          },
+        },
+      },
+    };
+
+    this.eventLogService.logEvent(event);
+  }
+
+  private emitExecute({
+    executionUuid,
+    startTimeIso,
+    endTimeIso,
+    durationNs,
+    scheduleDelayNs,
+    ruleId,
+    spaceId,
+    result,
+    error,
+  }: {
+    executionUuid: string;
+    startTimeIso: string;
+    endTimeIso: string;
+    durationNs: number;
+    scheduleDelayNs: number;
+    ruleId: string;
+    spaceId: string;
+    result: RuleExecutionPipelineResult;
+    error?: Error;
+  }): void {
+    const status = this.deriveExecutionStatus(result, error);
+    const outcome = status === 'success' ? 'success' : 'failure';
+    const alertEvents = result.finalState.alertEventsBatch ?? [];
+    const breachedCount = alertEvents.filter((e) => e.status === 'breached').length;
+    const recoveredCount = alertEvents.filter((e) => e.status === 'recovered').length;
+    const rowCount = result.finalState.esqlRowBatch?.length ?? 0;
+
+    const event: IEvent = {
+      '@timestamp': endTimeIso,
+      event: {
+        action: RULE_EXECUTOR_EVENT_ACTIONS.EXECUTE,
+        kind: 'event',
+        start: startTimeIso,
+        end: endTimeIso,
+        duration: String(durationNs),
+        outcome,
+        ...(result.haltReason ? { reason: result.haltReason } : {}),
+      },
+      ...(error ? { error: { message: error.message } } : {}),
+      ...(status !== 'success'
+        ? { message: error?.message ?? `Rule execution ${status}` }
+        : { message: 'Rule executed successfully' }),
+      kibana: {
+        saved_objects: [
+          {
+            type: RULE_SAVED_OBJECT_TYPE,
+            id: ruleId,
+            rel: SAVED_OBJECT_REL_PRIMARY,
+            namespace: spaceId === 'default' ? undefined : spaceId,
+          },
+        ],
+        space_ids: [spaceId],
+        task: {
+          schedule_delay: scheduleDelayNs,
+        },
+        alerting_v2: {
+          rule_executor: {
+            execution: {
+              uuid: executionUuid,
+              status,
+              metrics: {
+                query: {
+                  total_search_duration_ms: 0,
+                  number_of_rows_returned: rowCount,
+                },
+                events_written: {
+                  breached: breachedCount,
+                  recovered: recoveredCount,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    this.eventLogService.logEvent(event);
+  }
+
+  private deriveExecutionStatus(
+    result: RuleExecutionPipelineResult,
+    error?: Error
+  ): 'success' | 'warning' | 'failed' | 'timeout' | 'skipped' {
+    if (error) {
+      return 'failed';
+    }
+    if (result.completed) {
+      return 'success';
+    }
+    switch (result.haltReason) {
+      case 'rule_deleted':
+      case 'rule_disabled':
+        return 'skipped';
+      case 'state_not_ready':
+        return 'warning';
+      default:
+        return 'failed';
     }
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_setup.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_setup.ts
@@ -29,6 +29,7 @@ import {
   ACTION_POLICY_EVENT_ACTIONS,
   ACTION_POLICY_EVENT_PROVIDER,
 } from '../lib/dispatcher/steps/constants';
+import { RULE_EXECUTOR_EVENT_ACTIONS } from '../lib/rule_executor/constants';
 
 export function bindOnSetup({ bind }: ContainerModuleLoadOptions) {
   bind(OnSetup).toConstantValue((container) => {
@@ -66,7 +67,10 @@ export function bindOnSetup({ bind }: ContainerModuleLoadOptions) {
     );
     eventLogService.registerProviderActions(
       ACTION_POLICY_EVENT_PROVIDER,
-      Object.values(ACTION_POLICY_EVENT_ACTIONS)
+      [
+        ...Object.values(ACTION_POLICY_EVENT_ACTIONS),
+        ...Object.values(RULE_EXECUTOR_EVENT_ACTIONS),
+      ]
     );
     const eventLogger = eventLogService.getLogger({
       event: { provider: ACTION_POLICY_EVENT_PROVIDER },

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -753,6 +753,46 @@
                                     }
                                 }
                             }
+                        },
+                        "rule_executor": {
+                            "properties": {
+                                "execution": {
+                                    "properties": {
+                                        "uuid": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "status": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "metrics": {
+                                            "properties": {
+                                                "query": {
+                                                    "properties": {
+                                                        "total_search_duration_ms": {
+                                                            "type": "long"
+                                                        },
+                                                        "number_of_rows_returned": {
+                                                            "type": "long"
+                                                        }
+                                                    }
+                                                },
+                                                "events_written": {
+                                                    "properties": {
+                                                        "breached": {
+                                                            "type": "long"
+                                                        },
+                                                        "recovered": {
+                                                            "type": "long"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -333,6 +333,32 @@ export const EventSchema = schema.maybe(
                 ),
               })
             ),
+            rule_executor: schema.maybe(
+              schema.object({
+                execution: schema.maybe(
+                  schema.object({
+                    uuid: ecsString(),
+                    status: ecsString(),
+                    metrics: schema.maybe(
+                      schema.object({
+                        query: schema.maybe(
+                          schema.object({
+                            total_search_duration_ms: ecsNumber(),
+                            number_of_rows_returned: ecsNumber(),
+                          })
+                        ),
+                        events_written: schema.maybe(
+                          schema.object({
+                            breached: ecsNumber(),
+                            recovered: ecsNumber(),
+                          })
+                        ),
+                      })
+                    ),
+                  })
+                ),
+              })
+            ),
           })
         ),
       })

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -343,14 +343,14 @@ export const EventSchema = schema.maybe(
                       schema.object({
                         query: schema.maybe(
                           schema.object({
-                            total_search_duration_ms: ecsNumber(),
-                            number_of_rows_returned: ecsNumber(),
+                            total_search_duration_ms: ecsStringOrNumber(),
+                            number_of_rows_returned: ecsStringOrNumber(),
                           })
                         ),
                         events_written: schema.maybe(
                           schema.object({
-                            breached: ecsNumber(),
-                            recovered: ecsNumber(),
+                            breached: ecsStringOrNumber(),
+                            recovered: ecsStringOrNumber(),
                           })
                         ),
                       })

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -502,6 +502,46 @@ exports.EcsCustomPropertyMappings = {
               },
             },
           },
+          rule_executor: {
+            properties: {
+              execution: {
+                properties: {
+                  uuid: {
+                    type: 'keyword',
+                    ignore_above: 1024,
+                  },
+                  status: {
+                    type: 'keyword',
+                    ignore_above: 1024,
+                  },
+                  metrics: {
+                    properties: {
+                      query: {
+                        properties: {
+                          total_search_duration_ms: {
+                            type: 'long',
+                          },
+                          number_of_rows_returned: {
+                            type: 'long',
+                          },
+                        },
+                      },
+                      events_written: {
+                        properties: {
+                          breached: {
+                            type: 'long',
+                          },
+                          recovered: {
+                            type: 'long',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
     },

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/urls.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/urls.ts
@@ -42,3 +42,11 @@ export const READ_RULE_EXECUTION_RESULTS_URL =
   `${INTERNAL_URL}/rules/{ruleId}/execution/results` as const;
 export const readRuleExecutionResultsUrl = (ruleId: string) =>
   `${INTERNAL_URL}/rules/${ruleId}/execution/results` as const;
+
+// -------------------------------------------------------------------------------------------------
+// Rule execution logs API (v2 — RnA / Alerting v2)
+
+export const READ_V2_RULE_EXECUTION_RESULTS_URL =
+  `${INTERNAL_URL}/rules_v2/{ruleId}/execution/results` as const;
+export const readV2RuleExecutionResultsUrl = (ruleId: string) =>
+  `${INTERNAL_URL}/rules_v2/${ruleId}/execution/results` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/rules_v2/components/execution_log_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules_v2/components/execution_log_table.tsx
@@ -9,16 +9,25 @@ import React, { useState, useCallback, useMemo } from 'react';
 import type { EuiBasicTableColumn, CriteriaWithPagination } from '@elastic/eui';
 import {
   EuiBasicTable,
+  EuiFilterButton,
+  EuiFilterGroup,
+  EuiFilterSelectItem,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHealth,
+  EuiPopover,
+  EuiSpacer,
   EuiSuperDatePicker,
   EuiText,
   EuiTextBlockTruncate,
+  EuiTitle,
   EuiCallOut,
 } from '@elastic/eui';
 import type { UnifiedExecutionResult } from '../../../common/api/detection_engine/rule_monitoring';
 import { useV2ExecutionResults } from '../hooks/use_v2_execution_results';
+import { useBoolState } from '../../common/hooks/use_bool_state';
+
+type V2ExecutionStatus = 'success' | 'warning' | 'failure';
 
 const STATUS_COLOR: Record<string, string> = {
   success: 'success',
@@ -31,6 +40,8 @@ const STATUS_LABEL: Record<string, string> = {
   warning: 'Warning',
   failure: 'Failed',
 };
+
+const V2_STATUS_FILTERS: V2ExecutionStatus[] = ['success', 'warning', 'failure'];
 
 const formatDuration = (ms: number | null): string => {
   if (ms === null) return '—';
@@ -51,6 +62,12 @@ const columns: Array<EuiBasicTableColumn<UnifiedExecutionResult>> = [
     ),
   },
   {
+    field: 'run_type',
+    name: 'Run type',
+    width: '110px',
+    render: () => <EuiText size="s">Scheduled</EuiText>,
+  },
+  {
     field: 'execution_start',
     name: 'Timestamp',
     sortable: true,
@@ -61,24 +78,18 @@ const columns: Array<EuiBasicTableColumn<UnifiedExecutionResult>> = [
   },
   {
     field: 'execution_duration_ms',
-    name: 'Duration',
+    name: 'Execution duration',
     sortable: true,
-    width: '120px',
+    width: '150px',
     render: (value: number | null) => <EuiText size="s">{formatDuration(value)}</EuiText>,
   },
   {
     field: 'metrics.alert_counts.new',
-    name: 'Alerts',
-    width: '100px',
+    name: 'Alerts created',
+    width: '120px',
     render: (_: unknown, record: UnifiedExecutionResult) => (
       <EuiText size="s">{record.metrics.alert_counts?.new ?? 0}</EuiText>
     ),
-  },
-  {
-    field: 'metrics.total_search_duration_ms',
-    name: 'Search Duration',
-    width: '140px',
-    render: (value: number | null) => <EuiText size="s">{formatDuration(value)}</EuiText>,
   },
   {
     field: 'outcome.message',
@@ -96,18 +107,20 @@ interface ExecutionLogTableProps {
 }
 
 export const ExecutionLogTable: React.FC<ExecutionLogTableProps> = ({ ruleId }) => {
-  const [dateRange, setDateRange] = useState({ start: 'now-24h', end: 'now' });
+  const [dateRange, setDateRange] = useState({ start: 'now-2h', end: 'now' });
   const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(5);
   const [sortField, setSortField] = useState<'execution_start' | 'execution_duration_ms'>(
     'execution_start'
   );
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+  const [statusFilters, setStatusFilters] = useState<V2ExecutionStatus[]>([]);
 
-  const { data, isLoading, isError, error } = useV2ExecutionResults({
+  const { data, isLoading, isFetching, isError, error, refetch } = useV2ExecutionResults({
     ruleId,
     from: dateRange.start,
     to: dateRange.end,
+    outcome: statusFilters.length > 0 ? statusFilters : undefined,
     sortField,
     sortOrder: sortDirection,
     page: pageIndex + 1,
@@ -135,6 +148,10 @@ export const ExecutionLogTable: React.FC<ExecutionLogTableProps> = ({ ruleId }) 
     },
     []
   );
+
+  const onRefresh = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
   const pagination = useMemo(
     () => ({
@@ -166,17 +183,41 @@ export const ExecutionLogTable: React.FC<ExecutionLogTableProps> = ({ ruleId }) 
 
   return (
     <>
-      <EuiFlexGroup justifyContent="flexEnd" gutterSize="m">
+      <EuiFlexGroup gutterSize="s" alignItems="center">
+        <EuiFlexItem grow>
+          <div>
+            <EuiTitle size="xs">
+              <h3>Execution log</h3>
+            </EuiTitle>
+            <EuiText size="xs" color="subdued">
+              A log of rule execution results
+            </EuiText>
+          </div>
+        </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSuperDatePicker
-            start={dateRange.start}
-            end={dateRange.end}
-            onTimeChange={onTimeChange}
-            showUpdateButton={false}
-            compressed
-          />
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <StatusFilter
+                selectedItems={statusFilters}
+                onChange={setStatusFilters}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiSuperDatePicker
+                start={dateRange.start}
+                end={dateRange.end}
+                onTimeChange={onTimeChange}
+                onRefresh={onRefresh}
+                isLoading={isFetching}
+                width="auto"
+                data-test-subj="v2ExecutionLogDatePicker"
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
 
       <EuiBasicTable
         items={data?.data ?? []}
@@ -185,8 +226,64 @@ export const ExecutionLogTable: React.FC<ExecutionLogTableProps> = ({ ruleId }) 
         pagination={pagination}
         sorting={sorting}
         onChange={onTableChange}
+        tableCaption="A log of rule execution results"
         data-test-subj="v2ExecutionLogTable"
       />
     </>
+  );
+};
+
+const StatusFilter: React.FC<{
+  selectedItems: V2ExecutionStatus[];
+  onChange: (items: V2ExecutionStatus[]) => void;
+}> = ({ selectedItems, onChange }) => {
+  const [isOpen, , closePopover, togglePopover] = useBoolState();
+
+  const handleItemClick = useCallback(
+    (item: V2ExecutionStatus) => {
+      const next = selectedItems.includes(item)
+        ? selectedItems.filter((i) => i !== item)
+        : [...selectedItems, item];
+      onChange(next);
+    },
+    [selectedItems, onChange]
+  );
+
+  return (
+    <EuiFilterGroup data-test-subj="v2ExecutionStatusFilter">
+      <EuiPopover
+        button={
+          <EuiFilterButton
+            iconType="chevronSingleDown"
+            grow={false}
+            numFilters={V2_STATUS_FILTERS.length}
+            numActiveFilters={selectedItems.length}
+            hasActiveFilters={selectedItems.length > 0}
+            isSelected={isOpen}
+            onClick={togglePopover}
+            data-test-subj="v2ExecutionStatusFilterButton"
+          >
+            Status
+          </EuiFilterButton>
+        }
+        isOpen={isOpen}
+        closePopover={closePopover}
+        panelPaddingSize="none"
+        repositionOnScroll
+      >
+        {V2_STATUS_FILTERS.map((status) => (
+          <EuiFilterSelectItem
+            key={status}
+            checked={selectedItems.includes(status) ? 'on' : undefined}
+            onClick={() => handleItemClick(status)}
+            data-test-subj={`v2ExecutionStatusFilter-item-${status}`}
+          >
+            <EuiHealth color={STATUS_COLOR[status]}>
+              {STATUS_LABEL[status]}
+            </EuiHealth>
+          </EuiFilterSelectItem>
+        ))}
+      </EuiPopover>
+    </EuiFilterGroup>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/rules_v2/components/execution_log_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules_v2/components/execution_log_table.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useCallback, useMemo } from 'react';
+import type { EuiBasicTableColumn, CriteriaWithPagination } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiSuperDatePicker,
+  EuiText,
+  EuiTextBlockTruncate,
+  EuiCallOut,
+} from '@elastic/eui';
+import type { UnifiedExecutionResult } from '../../../common/api/detection_engine/rule_monitoring';
+import { useV2ExecutionResults } from '../hooks/use_v2_execution_results';
+
+const STATUS_COLOR: Record<string, string> = {
+  success: 'success',
+  warning: 'warning',
+  failure: 'danger',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  success: 'Succeeded',
+  warning: 'Warning',
+  failure: 'Failed',
+};
+
+const formatDuration = (ms: number | null): string => {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60000).toFixed(1)}m`;
+};
+
+const columns: Array<EuiBasicTableColumn<UnifiedExecutionResult>> = [
+  {
+    field: 'outcome.status',
+    name: 'Status',
+    width: '120px',
+    render: (_: unknown, record: UnifiedExecutionResult) => (
+      <EuiHealth color={STATUS_COLOR[record.outcome.status] ?? 'subdued'}>
+        {STATUS_LABEL[record.outcome.status] ?? record.outcome.status}
+      </EuiHealth>
+    ),
+  },
+  {
+    field: 'execution_start',
+    name: 'Timestamp',
+    sortable: true,
+    width: '220px',
+    render: (value: string) => (
+      <EuiText size="s">{new Date(value).toLocaleString()}</EuiText>
+    ),
+  },
+  {
+    field: 'execution_duration_ms',
+    name: 'Duration',
+    sortable: true,
+    width: '120px',
+    render: (value: number | null) => <EuiText size="s">{formatDuration(value)}</EuiText>,
+  },
+  {
+    field: 'metrics.alert_counts.new',
+    name: 'Alerts',
+    width: '100px',
+    render: (_: unknown, record: UnifiedExecutionResult) => (
+      <EuiText size="s">{record.metrics.alert_counts?.new ?? 0}</EuiText>
+    ),
+  },
+  {
+    field: 'metrics.total_search_duration_ms',
+    name: 'Search Duration',
+    width: '140px',
+    render: (value: number | null) => <EuiText size="s">{formatDuration(value)}</EuiText>,
+  },
+  {
+    field: 'outcome.message',
+    name: 'Message',
+    render: (_: unknown, record: UnifiedExecutionResult) => (
+      <EuiTextBlockTruncate lines={2}>
+        {record.outcome.message ?? '—'}
+      </EuiTextBlockTruncate>
+    ),
+  },
+];
+
+interface ExecutionLogTableProps {
+  ruleId: string;
+}
+
+export const ExecutionLogTable: React.FC<ExecutionLogTableProps> = ({ ruleId }) => {
+  const [dateRange, setDateRange] = useState({ start: 'now-24h', end: 'now' });
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [sortField, setSortField] = useState<'execution_start' | 'execution_duration_ms'>(
+    'execution_start'
+  );
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+
+  const { data, isLoading, isError, error } = useV2ExecutionResults({
+    ruleId,
+    from: dateRange.start,
+    to: dateRange.end,
+    sortField,
+    sortOrder: sortDirection,
+    page: pageIndex + 1,
+    perPage: pageSize,
+  });
+
+  const onTableChange = useCallback(
+    ({ page, sort }: CriteriaWithPagination<UnifiedExecutionResult>) => {
+      if (page) {
+        setPageIndex(page.index);
+        setPageSize(page.size);
+      }
+      if (sort) {
+        setSortField(sort.field as 'execution_start' | 'execution_duration_ms');
+        setSortDirection(sort.direction);
+      }
+    },
+    []
+  );
+
+  const onTimeChange = useCallback(
+    ({ start, end }: { start: string; end: string }) => {
+      setDateRange({ start, end });
+      setPageIndex(0);
+    },
+    []
+  );
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize,
+      totalItemCount: data?.total ?? 0,
+      pageSizeOptions: [5, 10, 25],
+    }),
+    [pageIndex, pageSize, data?.total]
+  );
+
+  const sorting = useMemo(
+    () => ({
+      sort: {
+        field: sortField,
+        direction: sortDirection,
+      },
+    }),
+    [sortField, sortDirection]
+  );
+
+  if (isError) {
+    return (
+      <EuiCallOut title="Failed to load execution results" color="danger" iconType="error">
+        {error instanceof Error ? error.message : String(error)}
+      </EuiCallOut>
+    );
+  }
+
+  return (
+    <>
+      <EuiFlexGroup justifyContent="flexEnd" gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiSuperDatePicker
+            start={dateRange.start}
+            end={dateRange.end}
+            onTimeChange={onTimeChange}
+            showUpdateButton={false}
+            compressed
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiBasicTable
+        items={data?.data ?? []}
+        columns={columns}
+        loading={isLoading}
+        pagination={pagination}
+        sorting={sorting}
+        onChange={onTableChange}
+        data-test-subj="v2ExecutionLogTable"
+      />
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/rules_v2/hooks/use_v2_execution_results.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules_v2/hooks/use_v2_execution_results.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import dateMath from '@kbn/datemath';
+import type { ReadRuleExecutionResultsResponse } from '../../../common/api/detection_engine/rule_monitoring';
+import { readV2RuleExecutionResultsUrl } from '../../../common/api/detection_engine/rule_monitoring';
+import { useKibana } from '../../common/lib/kibana';
+
+interface UseV2ExecutionResultsArgs {
+  ruleId: string;
+  from: string;
+  to: string;
+  outcome?: string[];
+  sortField?: 'execution_start' | 'execution_duration_ms';
+  sortOrder?: 'asc' | 'desc';
+  page?: number;
+  perPage?: number;
+}
+
+export const useV2ExecutionResults = (args: UseV2ExecutionResultsArgs) => {
+  const { http } = useKibana().services;
+  const { ruleId, from, to, outcome, sortField, sortOrder, page, perPage } = args;
+
+  return useQuery<ReadRuleExecutionResultsResponse>(
+    ['v2ExecutionResults', ruleId, from, to, outcome, sortField, sortOrder, page, perPage],
+    ({ signal }) => {
+      const url = readV2RuleExecutionResultsUrl(ruleId);
+
+      return http.fetch<ReadRuleExecutionResultsResponse>(url, {
+        method: 'POST',
+        version: '1',
+        body: JSON.stringify({
+          filter: {
+            from: dateMath.parse(from)?.toISOString(),
+            to: dateMath.parse(to, { roundUp: true })?.toISOString(),
+            outcome: outcome?.length ? outcome : undefined,
+          },
+          sort: sortField ? { field: sortField, order: sortOrder ?? 'desc' } : undefined,
+          page,
+          per_page: perPage,
+        }),
+        signal,
+      });
+    },
+    {
+      keepPreviousData: true,
+      refetchOnMount: 'always',
+      refetchOnWindowFocus: false,
+    }
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/rules_v2/pages/rules_v2_view_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules_v2/pages/rules_v2_view_page.tsx
@@ -206,15 +206,11 @@ const RuleViewTabs: React.FC<{
     },
     {
       id: 'execution-log',
-      name: 'Execution Log',
+      name: 'Execution results',
       content: (
         <>
           <EuiSpacer size="m" />
-          <EuiPanel paddingSize="l">
-            <EuiTitle size="xs">
-              <h3>Execution History</h3>
-            </EuiTitle>
-            <EuiSpacer size="m" />
+          <EuiPanel paddingSize="l" hasBorder>
             <ExecutionLogTable ruleId={ruleId} />
           </EuiPanel>
         </>

--- a/x-pack/solutions/security/plugins/security_solution/public/rules_v2/pages/rules_v2_view_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules_v2/pages/rules_v2_view_page.tsx
@@ -20,8 +20,10 @@ import {
   EuiPageHeader,
   EuiPanel,
   EuiSpacer,
+  EuiTabbedContent,
   EuiTitle,
 } from '@elastic/eui';
+import type { EuiTabbedContentTab } from '@elastic/eui';
 import { useQuery } from '@kbn/react-query';
 import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
@@ -29,6 +31,7 @@ import { useHistory, useParams } from 'react-router-dom';
 import { useKibana } from '../../common/lib/kibana';
 import { SecuritySolutionPageWrapper } from '../../common/components/page_wrapper';
 import { RULES_V2_PATH } from '../../../common/constants';
+import { ExecutionLogTable } from '../components/execution_log_table';
 import * as i18n from '../translations';
 
 export const RulesV2ViewPage = () => {
@@ -63,7 +66,10 @@ export const RulesV2ViewPage = () => {
     );
   }
 
-  const descriptionItems = [
+  const descriptionItems: Array<{
+    title: NonNullable<React.ReactNode>;
+    description: NonNullable<React.ReactNode>;
+  }> = [
     ...(rule.metadata.description
       ? [{ title: i18n.VIEW_DESCRIPTION_LABEL, description: rule.metadata.description }]
       : []),
@@ -152,29 +158,69 @@ export const RulesV2ViewPage = () => {
 
       <EuiSpacer size="l" />
 
-      <EuiFlexGroup>
-        <EuiFlexItem>
-          <EuiPanel paddingSize="l">
-            <EuiTitle size="xs">
-              <h3>{i18n.VIEW_RULE}</h3>
-            </EuiTitle>
-            <EuiSpacer size="m" />
-            <EuiDescriptionList listItems={descriptionItems} type="column" />
-          </EuiPanel>
-        </EuiFlexItem>
-
-        <EuiFlexItem>
-          <EuiPanel paddingSize="l">
-            <EuiTitle size="xs">
-              <h3>{i18n.VIEW_QUERY_LABEL}</h3>
-            </EuiTitle>
-            <EuiSpacer size="m" />
-            <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable>
-              {rule.evaluation.query.base}
-            </EuiCodeBlock>
-          </EuiPanel>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <RuleViewTabs rule={rule} ruleId={id} descriptionItems={descriptionItems} />
     </SecuritySolutionPageWrapper>
   );
+};
+
+const RuleViewTabs: React.FC<{
+  rule: RuleResponse;
+  ruleId: string;
+  descriptionItems: Array<{
+    title: NonNullable<React.ReactNode>;
+    description: NonNullable<React.ReactNode>;
+  }>;
+}> = ({ rule, ruleId, descriptionItems }) => {
+  const tabs: EuiTabbedContentTab[] = [
+    {
+      id: 'overview',
+      name: 'Overview',
+      content: (
+        <>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiPanel paddingSize="l">
+                <EuiTitle size="xs">
+                  <h3>{i18n.VIEW_RULE}</h3>
+                </EuiTitle>
+                <EuiSpacer size="m" />
+                <EuiDescriptionList listItems={descriptionItems} type="column" />
+              </EuiPanel>
+            </EuiFlexItem>
+
+            <EuiFlexItem>
+              <EuiPanel paddingSize="l">
+                <EuiTitle size="xs">
+                  <h3>{i18n.VIEW_QUERY_LABEL}</h3>
+                </EuiTitle>
+                <EuiSpacer size="m" />
+                <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable>
+                  {rule.evaluation.query.base}
+                </EuiCodeBlock>
+              </EuiPanel>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      ),
+    },
+    {
+      id: 'execution-log',
+      name: 'Execution Log',
+      content: (
+        <>
+          <EuiSpacer size="m" />
+          <EuiPanel paddingSize="l">
+            <EuiTitle size="xs">
+              <h3>Execution History</h3>
+            </EuiTitle>
+            <EuiSpacer size="m" />
+            <ExecutionLogTable ruleId={ruleId} />
+          </EuiPanel>
+        </>
+      ),
+    },
+  ];
+
+  return <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} autoFocus="selected" />;
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -189,6 +189,9 @@ const createSecuritySolutionRequestContextMock = (
     getDetectionRulesClient: jest.fn(() => clients.detectionRulesClient),
     getDetectionEngineHealthClient: jest.fn(() => clients.detectionEngineHealthClient),
     getRuleExecutionLog: jest.fn(() => clients.ruleExecutionLog),
+    getRuleExecutionLogV2: jest.fn(() => ({
+      getV2ExecutionResults: jest.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 10 }),
+    })),
     getExceptionListClient: jest.fn(() => clients.lists.exceptionListClient),
     getInternalFleetServices: jest.fn(
       () => clients.internalFleetServices as unknown as EndpointInternalFleetServicesInterface

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/register_routes.ts
@@ -11,6 +11,7 @@ import { getRuleHealthRoute } from './detection_engine_health/get_rule_health/ge
 import { getSpaceHealthRoute } from './detection_engine_health/get_space_health/get_space_health_route';
 import { setupHealthRoute } from './detection_engine_health/setup/setup_health_route';
 import { readRuleExecutionResultsRoute } from './rule_execution_logs/get_rule_execution_results/read_rule_execution_results_route';
+import { readV2RuleExecutionResultsRoute } from './rule_execution_logs/get_v2_rule_execution_results/read_v2_rule_execution_results_route';
 
 export const registerRuleMonitoringRoutes = (router: SecuritySolutionPluginRouter) => {
   // Detection Engine health API
@@ -21,4 +22,7 @@ export const registerRuleMonitoringRoutes = (router: SecuritySolutionPluginRoute
 
   // Rule execution logs API
   readRuleExecutionResultsRoute(router);
+
+  // Rule execution logs API (v2 — RnA / Alerting v2)
+  readV2RuleExecutionResultsRoute(router);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/rule_execution_logs/get_v2_rule_execution_results/read_v2_rule_execution_results_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/rule_execution_logs/get_v2_rule_execution_results/read_v2_rule_execution_results_route.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { schema } from '@kbn/config-schema';
+import type { IKibanaResponse } from '@kbn/core/server';
+import { transformError } from '@kbn/securitysolution-es-utils';
+import { RULES_API_READ } from '@kbn/security-solution-features/constants';
+import type { SecuritySolutionPluginRouter } from '../../../../../../types';
+import { buildSiemResponse } from '../../../../routes/utils';
+
+import type { ReadRuleExecutionResultsResponse } from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import { READ_V2_RULE_EXECUTION_RESULTS_URL } from '../../../../../../../common/api/detection_engine/rule_monitoring';
+
+export const readV2RuleExecutionResultsRoute = (router: SecuritySolutionPluginRouter) => {
+  router.versioned
+    .post({
+      access: 'internal',
+      path: READ_V2_RULE_EXECUTION_RESULTS_URL,
+      security: {
+        authz: {
+          requiredPrivileges: [RULES_API_READ],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            params: schema.object({
+              ruleId: schema.string(),
+            }),
+            body: schema.object({
+              filter: schema.maybe(
+                schema.object({
+                  from: schema.maybe(schema.string()),
+                  to: schema.maybe(schema.string()),
+                  outcome: schema.maybe(schema.arrayOf(schema.string())),
+                })
+              ),
+              sort: schema.maybe(
+                schema.object({
+                  field: schema.maybe(
+                    schema.oneOf([
+                      schema.literal('execution_start'),
+                      schema.literal('execution_duration_ms'),
+                    ])
+                  ),
+                  order: schema.maybe(
+                    schema.oneOf([schema.literal('asc'), schema.literal('desc')])
+                  ),
+                })
+              ),
+              page: schema.maybe(schema.number()),
+              per_page: schema.maybe(schema.number()),
+            }),
+          },
+        },
+      },
+      async (
+        context,
+        request,
+        response
+      ): Promise<IKibanaResponse<ReadRuleExecutionResultsResponse>> => {
+        const { ruleId } = request.params;
+        const { filter, sort, page, per_page: perPage } = request.body;
+
+        const siemResponse = buildSiemResponse(response);
+
+        try {
+          const ctx = await context.resolve(['securitySolution']);
+          const v2Client = ctx.securitySolution.getRuleExecutionLogV2();
+
+          const effectiveFilter = {
+            from: filter?.from ?? moment().subtract(2, 'hours').toISOString(),
+            to: filter?.to ?? moment().toISOString(),
+            outcome: filter?.outcome ?? [],
+          };
+
+          const executionResultsResponse = await v2Client.getV2ExecutionResults({
+            ruleId,
+            filter: effectiveFilter,
+            sort: sort ? { field: sort.field, order: sort.order } : undefined,
+            page,
+            perPage,
+          });
+
+          return response.ok({ body: executionResultsResponse });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/v2_event_log_constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/v2_event_log_constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ALERTING_V2_PROVIDER = 'alerting_v2';
+
+export const ALERTING_V2_RULE_SAVED_OBJECT_TYPE = 'alerting_rule';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_routes/v2_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_routes/v2_client.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { IEventLogClient } from '@kbn/event-log-plugin/server';
+
+import type {
+  ReadRuleExecutionResultsResponse,
+  UnifiedExecutionResultSortField,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import { assertUnreachable } from '../../../../../../../common/utility_types';
+
+import { withSecuritySpan } from '../../../../../../utils/with_security_span';
+import type { ExtMeta } from '../../utils/console_logging';
+
+import { ALERTING_V2_RULE_SAVED_OBJECT_TYPE } from '../../event_log/v2_event_log_constants';
+import { constructV2ExecutionEventKqlFilter } from '../event_log/construct_v2_execution_event_kql_filter';
+import { mapV2EventToUnifiedResult } from '../event_log/map_v2_event_to_unified_result';
+
+interface GetV2ExecutionResultsArgs {
+  ruleId: string;
+  filter?: {
+    from?: string;
+    to?: string;
+    outcome?: string[];
+  };
+  sort?: {
+    field?: UnifiedExecutionResultSortField;
+    order?: 'asc' | 'desc';
+  };
+  page?: number;
+  perPage?: number;
+}
+
+export interface IRuleExecutionLogV2ForRoutes {
+  getV2ExecutionResults(
+    args: GetV2ExecutionResultsArgs
+  ): Promise<ReadRuleExecutionResultsResponse>;
+}
+
+export const createRuleExecutionLogV2ClientForRoutes = (
+  eventLog: IEventLogClient,
+  logger: Logger
+): IRuleExecutionLogV2ForRoutes => {
+  return {
+    getV2ExecutionResults: (
+      args: GetV2ExecutionResultsArgs
+    ): Promise<ReadRuleExecutionResultsResponse> => {
+      return withSecuritySpan(
+        'IRuleExecutionLogV2ForRoutes.getV2ExecutionResults',
+        async () => {
+          const { ruleId } = args;
+          try {
+            const { filter: filterParams, sort, page, perPage } = args;
+            const { from, to, outcome } = filterParams ?? {};
+            const sortField = sort?.field ?? 'execution_start';
+            const sortOrder = sort?.order ?? 'desc';
+
+            const findResult = await eventLog.findEventsBySavedObjectIds(
+              ALERTING_V2_RULE_SAVED_OBJECT_TYPE,
+              [ruleId],
+              {
+                filter: constructV2ExecutionEventKqlFilter({ outcome }),
+                sort: [{ sort_field: mapSortField(sortField), sort_order: sortOrder }],
+                page,
+                per_page: perPage,
+                start: from,
+                end: to,
+              }
+            );
+
+            return {
+              data: findResult.data.map(mapV2EventToUnifiedResult),
+              total: findResult.total,
+              page: findResult.page,
+              per_page: findResult.per_page,
+            };
+          } catch (e) {
+            const logMessage = 'Error getting v2 execution results from event log';
+            const logReason = e instanceof Error ? e.message : String(e);
+            const logSuffix = `[rule id ${ruleId}]`;
+            const logMeta: ExtMeta = { rule: { id: ruleId } };
+
+            logger.error(`${logMessage}: ${logReason} ${logSuffix}`, logMeta);
+            throw e;
+          }
+        }
+      );
+    },
+  };
+};
+
+const mapSortField = (sortField: UnifiedExecutionResultSortField): string => {
+  switch (sortField) {
+    case 'execution_start':
+      return 'event.start';
+    case 'execution_duration_ms':
+      return 'event.duration';
+    default:
+      return assertUnreachable(sortField);
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/construct_v2_execution_event_kql_filter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/construct_v2_execution_event_kql_filter.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALERTING_V2_PROVIDER } from '../../event_log/v2_event_log_constants';
+import * as f from '../../event_log/event_log_fields';
+import { kqlAnd, kqlOr } from '../../utils/kql';
+
+/**
+ * Builds a KQL filter string for querying RnA v2 rule execution events.
+ *
+ * V2 events use:
+ *   provider: alerting_v2
+ *   action: execute (summary event after pipeline completes)
+ *
+ * Unlike v1, there is no "execute-backfill" action in v2 — backfill is not yet supported.
+ * The execute-start beacon is excluded because it has no metrics (it's a pre-pipeline marker).
+ */
+export const constructV2ExecutionEventKqlFilter = (filter: {
+  outcome?: string[];
+}): string => {
+  const filters: string[] = [
+    `${f.EVENT_PROVIDER}:${ALERTING_V2_PROVIDER}`,
+    `${f.EVENT_ACTION}:execute`,
+  ];
+
+  if (filter.outcome && filter.outcome.length > 0) {
+    const v2Statuses = mapOutcomesToV2Statuses(filter.outcome);
+    filters.push(
+      `kibana.alerting_v2.rule_executor.execution.status:(${kqlOr(v2Statuses)})`
+    );
+  }
+
+  return kqlAnd(filters);
+};
+
+/**
+ * Maps v1 outcome filter values to v2 status filter values.
+ *
+ * UI sends: success | warning | failure
+ * V2 uses:  success | warning | failed | timeout | skipped
+ */
+const mapOutcomesToV2Statuses = (outcomes: string[]): string[] => {
+  const statuses: string[] = [];
+
+  for (const outcome of outcomes) {
+    switch (outcome) {
+      case 'success':
+        statuses.push('success');
+        break;
+      case 'warning':
+        statuses.push('warning', 'skipped');
+        break;
+      case 'failure':
+        statuses.push('failed', 'timeout');
+        break;
+    }
+  }
+
+  return statuses;
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/map_v2_event_to_unified_result.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/map_v2_event_to_unified_result.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { UnifiedExecutionResult } from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import { invariant } from '../../../../../../../common/utils/invariant';
+import { nsToMs, toOptionalInt } from './utils';
+
+/**
+ * Maps an RnA v2 rule execution event (provider: alerting_v2, action: execute)
+ * to the same UnifiedExecutionResult shape used by the DE v1 execution history UI.
+ *
+ * V2 event field namespace: kibana.alerting_v2.rule_executor.*
+ * V1 event field namespace: kibana.alert.rule.execution.*
+ *
+ * This mapper allows the Security execution results table to render both v1 and v2
+ * execution events using the same component and data shape.
+ */
+export const mapV2EventToUnifiedResult = (event: IValidatedEvent): UnifiedExecutionResult => {
+  return {
+    execution_uuid: extractExecutionUuid(event),
+    execution_start: extractExecutionStart(event),
+    execution_duration_ms: extractDurationMs(event),
+    schedule_delay_ms: extractScheduleDelayMs(event),
+    backfill: null, // Backfill not supported in v2 yet (parity item #5)
+    outcome: extractOutcome(event),
+    metrics: extractMetrics(event),
+  };
+};
+
+const getRuleExecutor = (event: IValidatedEvent): Record<string, unknown> | undefined => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (event?.kibana as any)?.alerting_v2?.rule_executor;
+};
+
+const getExecution = (event: IValidatedEvent): Record<string, unknown> | undefined => {
+  const ruleExecutor = getRuleExecutor(event);
+  return ruleExecutor?.execution as Record<string, unknown> | undefined;
+};
+
+const getMetrics = (event: IValidatedEvent): Record<string, unknown> | undefined => {
+  const execution = getExecution(event);
+  return execution?.metrics as Record<string, unknown> | undefined;
+};
+
+const extractExecutionUuid = (event: IValidatedEvent): string | null => {
+  const execution = getExecution(event);
+  return (execution?.uuid as string) ?? null;
+};
+
+const extractExecutionStart = (event: IValidatedEvent): string => {
+  const executionStart = event?.event?.start ?? event?.['@timestamp'];
+  invariant(executionStart, 'Neither "event.start" nor "@timestamp" field is found in v2 event');
+  return executionStart;
+};
+
+const extractDurationMs = (event: IValidatedEvent): number | null =>
+  nsToMs(event?.event?.duration);
+
+const extractScheduleDelayMs = (event: IValidatedEvent): number | null =>
+  nsToMs(event?.kibana?.task?.schedule_delay);
+
+/**
+ * Maps the v2 5-way status to the v1 3-way UnifiedExecutionStatus.
+ *
+ * V2 statuses: success | warning | failed | timeout | skipped
+ * V1 statuses: success | warning | failure
+ *
+ * Mapping:
+ *   success  → success
+ *   warning  → warning
+ *   failed   → failure
+ *   timeout  → failure (with message noting timeout)
+ *   skipped  → warning (rule was skipped, not a hard failure)
+ */
+const extractOutcome = (event: IValidatedEvent): UnifiedExecutionResult['outcome'] => {
+  const execution = getExecution(event);
+  const v2Status = (execution?.status as string) ?? 'success';
+
+  let status: 'success' | 'warning' | 'failure';
+  let message: string | null;
+
+  switch (v2Status) {
+    case 'success':
+      status = 'success';
+      message = 'Rule executed successfully';
+      break;
+    case 'warning':
+      status = 'warning';
+      message = event?.message ?? null;
+      break;
+    case 'failed':
+      status = 'failure';
+      message = event?.error?.message ?? event?.message ?? null;
+      break;
+    case 'timeout':
+      status = 'failure';
+      message = `Rule execution timed out${event?.error?.message ? `: ${event.error.message}` : ''}`;
+      break;
+    case 'skipped':
+      status = 'warning';
+      message = `Rule execution skipped${event?.event?.reason ? `: ${event.event.reason}` : ''}`;
+      break;
+    default:
+      status = 'success';
+      message = null;
+  }
+
+  return { status, message };
+};
+
+const extractMetrics = (event: IValidatedEvent): UnifiedExecutionResult['metrics'] => {
+  const metrics = getMetrics(event);
+  const query = metrics?.query as Record<string, unknown> | undefined;
+  const eventsWritten = metrics?.events_written as Record<string, unknown> | undefined;
+
+  return {
+    total_search_duration_ms: toOptionalInt(query?.total_search_duration_ms),
+    total_indexing_duration_ms: null, // Not available in v2 schema
+    execution_gap_duration_s: null, // Gap detection not in v2 (parity item #5)
+    alerts_candidate_count: toOptionalInt(query?.number_of_rows_returned),
+    alert_counts: eventsWritten
+      ? { new: toOptionalInt(eventsWritten.breached) }
+      : null,
+    matched_indices_count: null, // DE-specific, not in v2
+    frozen_indices_queried_count: null, // DE-specific, not in v2
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -21,6 +21,7 @@ import type { ConfigType } from './config';
 import type { EndpointAppContextService } from './endpoint/endpoint_app_context_services';
 import { createDetectionRulesClient } from './lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client';
 import type { IRuleMonitoringService } from './lib/detection_engine/rule_monitoring';
+import { createRuleExecutionLogV2ClientForRoutes } from './lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_routes/v2_client';
 import { AssetCriticalityDataClient } from './lib/entity_analytics/asset_criticality';
 import { EntityStoreDataClient } from './lib/entity_analytics/entity_store/entity_store_data_client';
 import { RiskEngineDataClient } from './lib/entity_analytics/risk_engine/risk_engine_data_client';
@@ -268,6 +269,13 @@ export class RequestContextFactory implements IRequestContextFactory {
           savedObjectsClient: coreContext.savedObjects.client,
           eventLogClient: startPlugins.eventLog.getClient(request),
         })
+      ),
+
+      getRuleExecutionLogV2: memoize(() =>
+        createRuleExecutionLogV2ClientForRoutes(
+          startPlugins.eventLog.getClient(request),
+          options.logger
+        )
       ),
 
       siemMigrations: getSiemMigrationClients(siemMigrationsService, {

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -34,6 +34,7 @@ import type {
   IDetectionEngineHealthClient,
   IRuleExecutionLogForRoutes,
 } from './lib/detection_engine/rule_monitoring';
+import type { IRuleExecutionLogV2ForRoutes } from './lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_routes/v2_client';
 import type { FrameworkRequest } from './lib/framework';
 import type { EndpointAuthz } from '../common/endpoint/types/authz';
 import type { EndpointInternalFleetServicesInterface } from './endpoint/services/fleet';
@@ -70,6 +71,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getDetectionRulesClient: () => IDetectionRulesClient;
   getDetectionEngineHealthClient: () => IDetectionEngineHealthClient;
   getRuleExecutionLog: () => IRuleExecutionLogForRoutes;
+  getRuleExecutionLogV2: () => IRuleExecutionLogV2ForRoutes;
   getRacClient: (req: KibanaRequest) => Promise<AlertsClient>;
   getAuditLogger: () => AuditLogger | undefined;
   getLogger: () => Logger;


### PR DESCRIPTION
# Summary

Addresses https://github.com/elastic/security-team/issues/17106

## Main Changes
  - Adds execution event logging to the Alerting v2 Rule Executor pipeline (write path)
  - Adds a Security Solution read path + API + UI to consume those events (read path)
  - Wires end-to-end: rule runs on v2 → events in event log → visible in Execution Log table

## Problem

We want to be able to use the event log to view and investigate individual rule runs.

## Disclaimer
The RnA EventLog reporting is in active development, that is why as of now the v2 `RuleExecutorTaskRunner` (of the Alerting/_RnA_ v2) runs the pipeline without emitting any events to the Event Log.

The platform team is addressing these with the issues [rna-program#463](https://github.com/elastic/rna-program/issues/463) and [rna-program#92](https://github.com/elastic/rna-program/issues/92).

_**It is because of that, that as part of this POC I had to implement a minimal WRITE path for the Task Execution to the Event Log in order validate end-to-end independently.**_

## Code changes

### Event Log schema - _necessary for submitting the events._

Extended `kibana.alerting_v2` with a `rule_executor.execution` namespace: `uuid` (correlation ID), `status` (5-way: success/warning/failed/timeout/skipped), and metrics (`query.total_search_duration_ms`, `query.number_of_rows_returned`, `events_written.breached`, `events_written.recovered`).

### Alerting v2 WRITE path - _most likely a throwaway implementation, we need to catch up with Platform to see how to implement this._

Instruments `RuleExecutorTaskRunner` to emit two events per rule run:
  - `execute-start` -- lightweight beacon emitted before the pipeline (enables orphan/crash detection)
  - `execute` -- full summary emitted after the pipeline with status, duration, schedule delay, alert event counts from `finalState.alertEventsBatch`, and query metrics. Both share an `execution.uuid` for correlation.

 Status is derived from the pipeline result: `completed` → success, caught error → failed, `rule_disabled`/`rule_deleted` → skipped, `state_not_ready` → warning.


### Detection Engine READ path
 - Implemented new API for read rule execution results with filters.
 - Implemented UI for Execution logs similar to what we have in V1

## Known limitations

  | What | Why |
  |---|---|
  | `total_search_duration_ms` is always 0 | Currently the pipeline doesn't expose per-step timing |
  | No gap detection | Requires a Security hook into the v2 pipeline (parity item #5) |
  | No indexing duration | `StoreAlertEventsStep` doesn't expose write timing |
  | Run type is always "Scheduled" | v2 has no manual runs or backfills yet |
  | Health API not adapted for v2 | Aggregation builders hardcoded to v1 field paths |

## What is missing
 * No details flyout nor filter-by-execution-ID, might be a follow-on UI work, but we need some metrics to be available (Note: possibly could be out of scope for POC)  


 ### Identify risks

  | Risk | Severity | Mitigation |
  |---|---|---|
  | **Event Log schema changes are hand-edited** — the `mappings.json` and `schemas.ts` are generated files. We edited `mappings.js` (the source) and ran the generator (`scripts/create_schemas.js`), but the schema additions haven't gone through the full ECS review process. | Low | POC branch only. Production schema changes will go through the standard `create_schemas.js` pipeline and platform review. The field namespace (`kibana.alerting_v2.rule_executor.*`) is defined in [rna-program#463](https://github.com/elastic/rna-program/issues/463). |
  | **Write path instruments platform code Security doesn't own** — we modified `RuleExecutorTaskRunner`, `bind_on_setup.ts`, and Event Log schema in the `alerting_v2`  and `event_log` plugins. In production, the write path should be owned by the RnA platform team. | Medium | Clearly scoped as POC — the write path is ~200 lines and  intentionally minimal. Platform is building the production version in [kibana#268072 (https://github.com/elastic/kibana/pull/268072). Our changes should be replaced, not evolved. |
  | **Alert counts depend on `finalState.alertEventsBatch` being preserved** — the "Alerts created" metric counts `AlertEvent` objects from the pipeline's final state. If a future pipeline step clears or modifies `alertEventsBatch`, the count would silently break. | Low | `StoreAlertEventsStep` currently passes state through unchanged (`return { type: 'continue', state }`). The production write path ([kibana#268072](https://github.com/elastic/kibana/pull/268072)) uses a dedicated `RuleExecutionMetricsCollector` that records counts at each step, avoiding this dependency. | 
   | **`total_search_duration_ms` is hardcoded to 0** — the pipeline doesn't expose per-step timing, so query duration is always reported as 0ms. This could mislead  users inspecting execution performance. | Low | POC scope — the column is present to validate the UI layout and data flow. The production `RuleExecutionMetricsCollector` instruments `ExecuteRuleQueryStep` to capture actual ES search duration. |
  | **No integration tests** — the end-to-end flow (write → store → read → UI) is validated manually, not by automated tests. | Low | POC branch only. Production implementation should include Scout API integration tests (Bailey's PR has `rule_execution_events.spec.ts`). |


### Demo
<img width="1406" height="914" alt="Screenshot 2026-05-12 at 18 06 04" src="https://github.com/user-attachments/assets/7ab3fe80-7cd5-4a6d-b698-3558076a2b41" />


