### PR TITLE
[Alerting v2][Security Solution] Wire detection enrichments into rule executor

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/index.ts
@@ -35,3 +35,8 @@ export const module = new ContainerModule((options) => {
 
 export type { PluginConfig as AlertingV2Config } from './config';
 export type { AlertingServerStart, RulesClientApi } from './types';
+export { registerRuleExecutionRowEnricher } from './lib/rule_executor/row_enrichment/register_row_enricher';
+export type {
+  RuleExecutionRowEnrichContext,
+  RuleExecutionRowEnricher,
+} from './lib/rule_executor/row_enrichment/types';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/row_enrichment/register_row_enricher.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/row_enrichment/register_row_enricher.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleExecutionRowEnricher } from './types';
+
+let registeredRowEnricher: RuleExecutionRowEnricher | undefined;
+
+/**
+ * Registers (or replaces) the global row enricher invoked during alerting v2 rule execution.
+ * Intended for solution plugins such as Security that enrich detection-shaped rows before
+ * they are written to `.rule-events`.
+ */
+export const registerRuleExecutionRowEnricher = (enricher: RuleExecutionRowEnricher): void => {
+  registeredRowEnricher = enricher;
+};
+
+export const getRuleExecutionRowEnricher = (): RuleExecutionRowEnricher | undefined =>
+  registeredRowEnricher;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/row_enrichment/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/row_enrichment/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core/server';
+import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+
+import type { ExecutionContext } from '../../execution_context';
+
+/**
+ * Context passed to optional row enrichers after ES|QL rows are materialized and
+ * before they are converted into `.rule-events` alert events.
+ */
+export interface RuleExecutionRowEnrichContext {
+  readonly rule: RuleResponse;
+  readonly spaceId: string;
+  readonly rows: ReadonlyArray<Record<string, unknown>>;
+  readonly executionContext: ExecutionContext;
+  readonly scopedClusterClient: IScopedClusterClient;
+}
+
+/**
+ * Pluggable enrichment for rule execution rows. Implementations should return a new
+ * array with the same length and ordering as `rows` when possible.
+ */
+export type RuleExecutionRowEnricher = (
+  ctx: RuleExecutionRowEnrichContext
+) => Promise<ReadonlyArray<Record<string, unknown>>>;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/enrich_esql_rows_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/enrich_esql_rows_step.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core/server';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+
+import { EnrichEsqlRowsStep } from './enrich_esql_rows_step';
+import {
+  collectStreamResults,
+  createPipelineStream,
+  createRulePipelineState,
+  createRuleResponse,
+} from '../test_utils';
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
+import {
+  getRuleExecutionRowEnricher,
+  registerRuleExecutionRowEnricher,
+} from '../row_enrichment/register_row_enricher';
+
+describe('EnrichEsqlRowsStep', () => {
+  let step: EnrichEsqlRowsStep;
+  let scopedClusterClient: jest.Mocked<IScopedClusterClient>;
+
+  beforeEach(() => {
+    const { loggerService } = createLoggerService();
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    scopedClusterClient = {
+      asCurrentUser: esClient,
+      asInternalUser: esClient,
+    } as unknown as jest.Mocked<IScopedClusterClient>;
+    step = new EnrichEsqlRowsStep(loggerService, scopedClusterClient);
+  });
+
+  afterEach(() => {
+    registerRuleExecutionRowEnricher(async (ctx) => ctx.rows);
+    jest.clearAllMocks();
+  });
+
+  it('passes rows through when enricher returns the same logical rows', async () => {
+    registerRuleExecutionRowEnricher(async (ctx) => ctx.rows);
+    const rows = [{ 'host.name': 'a' }];
+    const state = createRulePipelineState({
+      rule: createRuleResponse(),
+      esqlRowBatch: rows,
+    });
+
+    const [result] = await collectStreamResults(step.executeStream(createPipelineStream([state])));
+
+    expect(result.type).toBe('continue');
+    if (result.type === 'continue') {
+      expect(result.state.esqlRowBatch).toEqual(rows);
+    }
+  });
+
+  it('applies registered enricher before alert events are built', async () => {
+    registerRuleExecutionRowEnricher(async (ctx) =>
+      ctx.rows.map((row) => ({ ...row, test_enrichment: true }))
+    );
+
+    const rows = [{ 'host.name': 'a' }];
+    const state = createRulePipelineState({
+      rule: createRuleResponse(),
+      esqlRowBatch: rows,
+    });
+
+    const [result] = await collectStreamResults(step.executeStream(createPipelineStream([state])));
+
+    expect(result.type).toBe('continue');
+    if (result.type === 'continue') {
+      expect(result.state.esqlRowBatch).toEqual([{ 'host.name': 'a', test_enrichment: true }]);
+    }
+    expect(getRuleExecutionRowEnricher()).toBeDefined();
+  });
+
+  it('halts with state_not_ready when rule or esqlRowBatch is missing', async () => {
+    const state = createRulePipelineState();
+    const [result] = await collectStreamResults(step.executeStream(createPipelineStream([state])));
+
+    expect(result).toEqual({ type: 'halt', reason: 'state_not_ready', state });
+  });
+
+  it('returns original rows when enricher throws', async () => {
+    registerRuleExecutionRowEnricher(async () => {
+      throw new Error('boom');
+    });
+
+    const rows = [{ 'host.name': 'a' }];
+    const state = createRulePipelineState({
+      rule: createRuleResponse(),
+      esqlRowBatch: rows,
+    });
+
+    const [result] = await collectStreamResults(step.executeStream(createPipelineStream([state])));
+
+    expect(result).toEqual({ type: 'continue', state });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/enrich_esql_rows_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/enrich_esql_rows_step.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core/server';
+import { inject, injectable } from 'inversify';
+
+import type { PipelineStateStream, RuleExecutionStep } from '../types';
+import { getRuleExecutionRowEnricher } from '../row_enrichment/register_row_enricher';
+import {
+  LoggerServiceToken,
+  type LoggerServiceContract,
+} from '../../services/logger_service/logger_service';
+import { ScopedClusterClientToken } from '../../services/es_service/scoped_cluster_tokens';
+import { guardedMapStep } from '../stream_utils';
+
+@injectable()
+export class EnrichEsqlRowsStep implements RuleExecutionStep {
+  public readonly name = 'enrich_esql_rows';
+
+  constructor(
+    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
+    @inject(ScopedClusterClientToken) private readonly scopedClusterClient: IScopedClusterClient
+  ) {}
+
+  public executeStream(streamState: PipelineStateStream): PipelineStateStream {
+    return guardedMapStep(streamState, ['rule', 'esqlRowBatch'], async (state) => {
+      const enricher = getRuleExecutionRowEnricher();
+      if (!enricher || state.esqlRowBatch.length === 0) {
+        return { type: 'continue', state };
+      }
+
+      if (state.input.executionContext.signal.aborted) {
+        return { type: 'continue', state };
+      }
+
+      this.logger.debug({
+        message: () =>
+          `[${this.name}] Running row enricher for rule ${state.input.ruleId} (${state.esqlRowBatch.length} rows)`,
+      });
+
+      try {
+        const enrichedRows = await enricher({
+          rule: state.rule,
+          spaceId: state.input.spaceId,
+          rows: state.esqlRowBatch,
+          executionContext: state.input.executionContext,
+          scopedClusterClient: this.scopedClusterClient,
+        });
+
+        return {
+          type: 'continue',
+          state: {
+            ...state,
+            esqlRowBatch: [...enrichedRows],
+          },
+        };
+      } catch (error) {
+        this.logger.error({
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+        return { type: 'continue', state };
+      }
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/index.ts
@@ -9,6 +9,7 @@ export { WaitForResourcesStep } from './wait_for_resources_step';
 export { FetchRuleStep } from './fetch_rule_step';
 export { ValidateRuleStep } from './validate_rule_step';
 export { ExecuteRuleQueryStep } from './execute_rule_query_step';
+export { EnrichEsqlRowsStep } from './enrich_esql_rows_step';
 export { CreateAlertEventsStep } from './create_alert_events_step';
 export { ApplyDetectionEngineFeaturesStep } from './apply_detection_engine_features_step';
 export { CreateRecoveryEventsStep } from './create_recovery_events_step';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/es_service/scoped_cluster_tokens.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/es_service/scoped_cluster_tokens.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core/server';
+import type { ServiceIdentifier } from 'inversify';
+
+/**
+ * Request-scoped Elasticsearch cluster client (current + internal users), used when
+ * enrichers need the same access pattern as other rule execution code.
+ */
+export const ScopedClusterClientToken = Symbol.for(
+  'alerting_v2.ScopedClusterClient'
+) as ServiceIdentifier<IScopedClusterClient>;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_rule_executor.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_rule_executor.ts
@@ -16,6 +16,7 @@ import {
   FetchRuleStep,
   ValidateRuleStep,
   ExecuteRuleQueryStep,
+  EnrichEsqlRowsStep,
   CreateAlertEventsStep,
   ApplyDetectionEngineFeaturesStep,
   CreateRecoveryEventsStep,
@@ -52,6 +53,7 @@ export const bindRuleExecutionServices = ({ bind }: ContainerModuleLoadOptions) 
   bind(RuleExecutionStepsToken).to(FetchRuleStep).inRequestScope();
   bind(RuleExecutionStepsToken).to(ValidateRuleStep).inSingletonScope();
   bind(RuleExecutionStepsToken).to(ExecuteRuleQueryStep).inRequestScope();
+  bind(RuleExecutionStepsToken).to(EnrichEsqlRowsStep).inRequestScope();
   bind(RuleExecutionStepsToken).to(CreateAlertEventsStep).inSingletonScope();
   bind(RuleExecutionStepsToken).to(ApplyDetectionEngineFeaturesStep).inSingletonScope();
   bind(RuleExecutionStepsToken).to(CreateRecoveryEventsStep).inRequestScope();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -27,6 +27,7 @@ import { RulesClient } from '../lib/rules_client';
 import { RulesClientSpaceIdToken } from '../lib/rules_client/tokens';
 import { ApiKeyService } from '../lib/services/api_key_service/api_key_service';
 import { EsServiceInternalToken, EsServiceScopedToken } from '../lib/services/es_service/tokens';
+import { ScopedClusterClientToken } from '../lib/services/es_service/scoped_cluster_tokens';
 import { EventLogService } from '../lib/services/event_log_service/event_log_service';
 import { EventLogServiceToken } from '../lib/services/event_log_service/tokens';
 import { LoggerService, LoggerServiceToken } from '../lib/services/logger_service/logger_service';
@@ -161,6 +162,14 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
       const request = get(Request);
       const elasticsearch = get(CoreStart('elasticsearch'));
       return elasticsearch.client.asScoped(request).asCurrentUser;
+    })
+    .inRequestScope();
+
+  bind(ScopedClusterClientToken)
+    .toDynamicValue(({ get }) => {
+      const request = get(Request);
+      const elasticsearch = get(CoreStart('elasticsearch'));
+      return elasticsearch.client.asScoped(request);
     })
     .inRequestScope();
 

--- a/x-pack/solutions/security/plugins/security_solution/moon.yml
+++ b/x-pack/solutions/security/plugins/security_solution/moon.yml
@@ -32,6 +32,7 @@ dependsOn:
   - '@kbn/unified-search-plugin'
   - '@kbn/actions-plugin'
   - '@kbn/alerting-plugin'
+  - '@kbn/alerting-v2-plugin'
   - '@kbn/cases-plugin'
   - '@kbn/cloud-security-posture-plugin'
   - '@kbn/encrypted-saved-objects-plugin'

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/alerting_v2/register_row_enricher.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/alerting_v2/register_row_enricher.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { registerRuleExecutionRowEnricher } from '@kbn/alerting-v2-plugin/server';
+import { set } from '@kbn/safer-lodash-set';
+import type { Logger } from '@kbn/logging';
+
+import type { DetectionAlertLatest } from '../../../../common/api/detection_engine/model/alerts';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import { enrichEvents } from '../rule_types/utils/enrichments';
+import type { AlertEnrichmentLogger } from '../rule_types/utils/enrichments/types';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+/**
+ * ES|QL row payloads use flat dotted keys (e.g. `{ "host.name": "host-a" }`).
+ * The Security enrichers walk nested paths via `lodash.get` and `euid.getEuidFromObject`,
+ * which expect `{ host: { name: "host-a" } }`. Expand dotted keys into a nested object so
+ * enrichment lookups (EUID, risk, criticality) can locate `host.name`, `user.name`, etc.
+ */
+const expandDottedKeys = (row: Record<string, unknown>): Record<string, unknown> => {
+  const expanded: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (key.includes('.')) {
+      set(expanded, key, value);
+    } else {
+      expanded[key] = value;
+    }
+  }
+  return expanded;
+};
+
+/**
+ * Flattens enriched alert source back into ES|QL-style flat dotted keys, since downstream
+ * `.rule-events` `data` consumers (and `group_hash` computation) read flat keys.
+ */
+const flattenToDottedKeys = (
+  source: Record<string, unknown>,
+  prefix = ''
+): Record<string, unknown> => {
+  const flat: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype
+    ) {
+      Object.assign(flat, flattenToDottedKeys(value as Record<string, unknown>, next));
+    } else {
+      flat[next] = value;
+    }
+  }
+  return flat;
+};
+
+const createRowEnrichmentLogger = (base: Logger, ruleId: string): AlertEnrichmentLogger => ({
+  debug: (message: string) => {
+    base.debug(`[alertingV2][rowEnrichment][rule:${ruleId}] ${message}`);
+  },
+  info: (message: string) => {
+    base.info(`[alertingV2][rowEnrichment][rule:${ruleId}] ${message}`);
+  },
+  error: (message: string) => {
+    base.error(`[alertingV2][rowEnrichment][rule:${ruleId}] ${message}`);
+  },
+});
+
+/**
+ * Wires Security Solution detection enrichments into alerting v2 rule execution so ES|QL
+ * row payloads are merged with risk and asset criticality fields before `.rule-events`
+ * documents are built.
+ */
+export const registerSecuritySolutionAlertingV2RowEnricher = (params: {
+  logger: Logger;
+  getStartServices: SecuritySolutionPluginCoreSetupDependencies['getStartServices'];
+  getExperimentalFeatures: () => ExperimentalFeatures;
+}): void => {
+  const { logger, getStartServices, getExperimentalFeatures } = params;
+
+  registerRuleExecutionRowEnricher(async (ctx) => {
+    if (ctx.rows.length === 0) {
+      return ctx.rows;
+    }
+
+    const [, startPlugins] = await getStartServices();
+    const experimentalFeatures = getExperimentalFeatures();
+
+    const entityStoreCrudClient = experimentalFeatures.entityAnalyticsEntityStoreV2
+      ? startPlugins.entityStore.createCRUDClient(
+          ctx.scopedClusterClient.asCurrentUser,
+          ctx.spaceId
+        )
+      : undefined;
+
+    const events = ctx.rows.map((row, index) => ({
+      _id: `alerting-v2-enrichment:${ctx.rule.id}:${index}`,
+      _source: expandDottedKeys(row) as unknown as DetectionAlertLatest,
+    }));
+
+    const enrichmentLogger = createRowEnrichmentLogger(logger, ctx.rule.id);
+
+    const enriched = await enrichEvents({
+      services: { scopedClusterClient: ctx.scopedClusterClient },
+      logger: enrichmentLogger,
+      events,
+      spaceId: ctx.spaceId,
+      experimentalFeatures,
+      entityStoreCrudClient,
+    });
+
+    return enriched.map((event) =>
+      flattenToDottedKeys(event._source as unknown as Record<string, unknown>)
+    );
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.ts
@@ -10,11 +10,11 @@ import { euid } from '@kbn/entity-store/common/euid_helpers';
 import type { EntityStoreCRUDClient } from '@kbn/entity-store/server';
 import type { DetectionAlertLatest } from '../../../../../../common/api/detection_engine/model/alerts';
 import type {
+  AlertEnrichmentLogger,
   CreateV2EnrichmentFunction,
   EventsForEnrichment,
   EventsMapByEnrichments,
 } from './types';
-import type { IRuleExecutionLogForExecutors } from '../../../rule_monitoring';
 
 const CHUNK_SIZE = 1000;
 
@@ -63,7 +63,7 @@ export const createEntityStoreEnrichment = async <T extends DetectionAlertLatest
   name: string;
   entityType: 'host' | 'user' | 'service';
   entityStoreCrudClient: EntityStoreCRUDClient;
-  logger: IRuleExecutionLogForExecutors;
+  logger: AlertEnrichmentLogger;
   events: Array<EventsForEnrichment<T>>;
   enrichmentFields: string[];
   createEnrichmentFunction: CreateV2EnrichmentFunction;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/types.ts
@@ -16,6 +16,14 @@ import type {
 } from '../../../../../../common/api/detection_engine/model/alerts';
 import type { SecurityRuleServices } from '../../types';
 import type { IRuleExecutionLogForExecutors } from '../../../rule_monitoring';
+
+/** Narrow ES surface used by alert enrichment (legacy rules and alerting v2 rows). */
+export type AlertEnrichmentElasticsearchServices = Pick<
+  SecurityRuleServices,
+  'scopedClusterClient'
+>;
+
+export type AlertEnrichmentLogger = Pick<IRuleExecutionLogForExecutors, 'debug' | 'error' | 'info'>;
 import type { ExperimentalFeatures } from '../../../../../../common/experimental_features';
 
 export type EnrichmentType = estypes.SearchHit<unknown>;
@@ -40,12 +48,12 @@ export type MergeEnrichments = <T extends DetectionAlertLatest>(
 export type ApplyEnrichmentsToEvents = <T extends DetectionAlertLatest>(params: {
   events: Array<EventsForEnrichment<T>>;
   enrichmentsList: EventsMapByEnrichments[];
-  logger: IRuleExecutionLogForExecutors;
+  logger: AlertEnrichmentLogger;
 }) => Array<EventsForEnrichment<T>>;
 
 export interface BasedEnrichParameters<T extends DetectionAlertLatest> {
-  services: SecurityRuleServices;
-  logger: IRuleExecutionLogForExecutors;
+  services: AlertEnrichmentElasticsearchServices;
+  logger: AlertEnrichmentLogger;
   events: Array<EventsForEnrichment<T>>;
   entityStoreCrudClient?: EntityStoreCRUDClient;
 }
@@ -69,19 +77,19 @@ export type MakeSingleFieldMatchQuery = (params: {
 
 export type SearchEnrichments = (params: {
   index: string[];
-  services: SecurityRuleServices;
-  logger: IRuleExecutionLogForExecutors;
+  services: AlertEnrichmentElasticsearchServices;
+  logger: AlertEnrichmentLogger;
   query: Filter;
   fields: string[];
 }) => Promise<EnrichmentType[]>;
 
 export type GetIsRiskScoreAvailable = (params: {
   spaceId: string;
-  services: SecurityRuleServices;
+  services: AlertEnrichmentElasticsearchServices;
 }) => Promise<boolean>;
 
 export type IsIndexExist = (params: {
-  services: SecurityRuleServices;
+  services: AlertEnrichmentElasticsearchServices;
   index: string;
 }) => Promise<boolean>;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -101,6 +101,7 @@ import {
   createSecurityRuleTypeWrapper,
   securityRuleTypeFieldMap,
 } from './lib/detection_engine/rule_types/create_security_rule_type_wrapper';
+import { registerSecuritySolutionAlertingV2RowEnricher } from './lib/detection_engine/alerting_v2/register_row_enricher';
 
 import { RequestContextFactory } from './request_context_factory';
 
@@ -622,6 +623,12 @@ export class Plugin implements ISecuritySolutionPlugin {
     );
     plugins.alerting.registerType(securityRuleTypeWrapper(createThresholdAlertType()));
     plugins.alerting.registerType(securityRuleTypeWrapper(createNewTermsAlertType()));
+
+    registerSecuritySolutionAlertingV2RowEnricher({
+      logger: this.logger,
+      getStartServices: core.getStartServices,
+      getExperimentalFeatures: () => this.config.experimentalFeatures,
+    });
 
     const trialCompanionDeps: TrialCompanionRoutesDeps = {
       router,

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/unified-search-plugin",
     "@kbn/actions-plugin",
     "@kbn/alerting-plugin",
+    "@kbn/alerting-v2-plugin",
     "@kbn/cases-plugin",
     "@kbn/cloud-security-posture-plugin",
     "@kbn/encrypted-saved-objects-plugin",


### PR DESCRIPTION
## Summary

Wires Security Solution detection enrichments (entity store risk, asset criticality, legacy risk index) into the alerting v2 rule execution pipeline, so enriched fields land on `.rule-events` alert episode payloads next to the ES|QL row data.

### Alerting v2

- New `EnrichEsqlRowsStep` runs between `ExecuteRuleQueryStep` and `CreateAlertEventsStep`. It looks up a globally registered `RuleExecutionRowEnricher` and invokes it with the current `rule`, `spaceId`, `rows`, `executionContext`, and a request-scoped `IScopedClusterClient`. Failures are logged; the original row batch is preserved.
- New `registerRuleExecutionRowEnricher` public API exported from `@kbn/alerting-v2-plugin/server` so solution plugins can plug in without depending on alerting v2 internals.
- New `ScopedClusterClientToken` request-scoped binding so enrichers get the same scoped ES client surface (`asCurrentUser` / `asInternalUser`) the rest of the rule executor uses.
- Unit test coverage in `enrich_esql_rows_step.test.ts`.

### Security Solution

- Narrowed enrichment types (`AlertEnrichmentElasticsearchServices`, `AlertEnrichmentLogger`) so `enrichEvents` and friends no longer require the full `SecurityRuleServices` / `IRuleExecutionLogForExecutors` surface. Existing v1 callers continue to satisfy the wider type.
- New `registerSecuritySolutionAlertingV2RowEnricher`:
  - resolves `entityStoreCrudClient` when `entityAnalyticsEntityStoreV2` is enabled,
  - expands ES|QL flat dotted-key rows (e.g. `{ "host.name": "host-a" }`) into the nested object shape that `euid.getEuidFromObject` and the lodash-based field accessors expect,
  - calls `enrichEvents` with the rule's scoped cluster client and a lightweight logger adapter,
  - flattens the enriched `_source` back to dotted keys so `group_hash` computation and `.rule-events.data` (a `flattened` field) keep their existing semantics.
- Wired into `Plugin#setup`. Added `@kbn/alerting-v2-plugin` to Security Solution `tsconfig.json` and `moon.yml`.

### Why enrichments live on `.rule-events`, not `.alert-actions`

`.rule-events` is the durable history of rule evaluation; its `data` field is the ES|QL row payload — the natural home for "what we observed, including enrichment context." `.alert-actions` is the dispatcher's action history (fire / notified / suppress / ack / snooze / tag / etc.) and is intentionally append-only with strict mappings. Enrichments are part of the detection snapshot, so they belong on the rule event, not on the action log.

## Test plan

- [ ] `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/enrich_esql_rows_step.test.ts`
- [ ] `node scripts/check_changes.ts`
- [ ] Manual: enable `xpack.alerting_v2.enabled: true`, seed an entity (`host:host-a`) in the entity store, create an alerting v2 rule whose ES|QL query emits a row with `host.name = "host-a"`, and confirm `.rule-events.data` carries `kibana.alert.host.risk.calculated_level` / `calculated_score_norm`.
- [ ] Manual negative control: disable `entityAnalyticsEntityStoreV2`, rerun, and confirm enrichment fields are absent from `data`.
